### PR TITLE
style: (#23) 메인 방 카드 및 헤더 UI 보정

### DIFF
--- a/src/pages/main/ui/MainHeader.tsx
+++ b/src/pages/main/ui/MainHeader.tsx
@@ -8,8 +8,13 @@ const MainHeader = () => {
           <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 to-indigo-600 text-white shadow-[0_10px_24px_rgba(99,102,241,0.25)]">
             <UsersRound className="h-5 w-5" />
           </div>
-          <div className="text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">
-            점심메이트<span className="text-indigo-500">추가</span>
+          <div className="flex flex-col">
+            <span className="text-[22px] font-extrabold tracking-[-0.03em] text-slate-900">
+              점메추
+            </span>
+            <span className="text-xs font-medium tracking-[0.02em] text-slate-400">
+              점심메이트 추천
+            </span>
           </div>
         </div>
 

--- a/src/pages/main/ui/MainTabs.tsx
+++ b/src/pages/main/ui/MainTabs.tsx
@@ -1,4 +1,5 @@
 import { List, Soup, TrendingUp, UsersRound } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
 
 const tabItems = [
   { label: '점심 방', icon: UsersRound, isActive: true },
@@ -18,12 +19,12 @@ const MainTabs = () => {
             <button
               key={tabItem.label}
               type="button"
-              className={[
+              className={cn(
                 'inline-flex items-center justify-center gap-2 rounded-[18px] px-4 py-[14px] text-[15px] font-semibold transition',
                 tabItem.isActive
                   ? 'bg-indigo-500 text-white shadow-[0_10px_24px_rgba(99,102,241,0.24)]'
                   : 'text-slate-500 hover:bg-slate-50',
-              ].join(' ')}
+              )}
             >
               <Icon className="h-4 w-4" />
               {tabItem.label}

--- a/src/pages/main/ui/RoomCard.tsx
+++ b/src/pages/main/ui/RoomCard.tsx
@@ -8,34 +8,50 @@ interface RoomCardProps {
 
 const roomTypeStyleMap = {
   MALE: {
-    accentClassName: 'bg-blue-500',
+    badgeClassName: 'bg-sky-100 text-sky-700',
     badgeLabel: '남성만',
+    cardClassName: 'border-sky-100 bg-sky-50/50',
+    progressClassName: 'bg-sky-500',
+    buttonClassName:
+      'bg-sky-500 text-white hover:bg-sky-600 shadow-[0_10px_24px_rgba(14,165,233,0.2)]',
   },
   FEMALE: {
-    accentClassName: 'bg-pink-500',
+    badgeClassName: 'bg-rose-100 text-rose-700',
     badgeLabel: '여성만',
+    cardClassName: 'border-rose-100 bg-rose-50/50',
+    progressClassName: 'bg-rose-500',
+    buttonClassName:
+      'bg-rose-500 text-white hover:bg-rose-600 shadow-[0_10px_24px_rgba(244,63,94,0.18)]',
   },
   MIXED: {
-    accentClassName: 'bg-indigo-500',
+    badgeClassName: 'bg-indigo-100 text-indigo-700',
     badgeLabel: '혼성',
+    cardClassName: 'border-indigo-100 bg-indigo-50/50',
+    progressClassName: 'bg-indigo-500',
+    buttonClassName:
+      'bg-indigo-500 text-white hover:bg-indigo-600 shadow-[0_10px_24px_rgba(99,102,241,0.22)]',
   },
 } as const;
 
 const RoomCard = ({ room }: RoomCardProps) => {
-  const { accentClassName, badgeLabel } = roomTypeStyleMap[room.roomType];
+  const { badgeClassName, badgeLabel, buttonClassName, cardClassName, progressClassName } =
+    roomTypeStyleMap[room.roomType];
   const progressPercent = (room.currentCount / room.capacity) * 100;
   const remainingCount = room.capacity - room.currentCount;
 
   return (
-    <article className="overflow-hidden rounded-[28px] border border-slate-200/80 bg-white shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
-      <div className="flex gap-4 p-5 md:p-6">
-        <div className={`w-[5px] rounded-full ${accentClassName}`} />
-
-        <div className="min-w-0 flex-1">
+    <article
+      className={[
+        'overflow-hidden rounded-[28px] border shadow-[0_12px_30px_rgba(15,23,42,0.05)]',
+        cardClassName,
+      ].join(' ')}
+    >
+      <div className="p-5 md:p-6">
+        <div className="min-w-0">
           <h2 className="text-[19px] font-bold tracking-[-0.03em] text-slate-900">{room.title}</h2>
 
           <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-500">
-            <span className="rounded-md bg-slate-100 px-2 py-1 font-medium text-slate-600">
+            <span className={['rounded-md px-2 py-1 font-medium', badgeClassName].join(' ')}>
               {badgeLabel}
             </span>
             <span className="rounded-md bg-slate-100 px-2 py-1 font-medium text-slate-600">
@@ -65,14 +81,17 @@ const RoomCard = ({ room }: RoomCardProps) => {
 
           <div className="mt-5 h-2 overflow-hidden rounded-full bg-slate-100">
             <div
-              className={`h-full rounded-full ${accentClassName}`}
+              className={['h-full rounded-full', progressClassName].join(' ')}
               style={{ width: `${progressPercent}%` }}
             />
           </div>
 
           <button
             type="button"
-            className="mt-4 w-full rounded-2xl bg-slate-100 px-4 py-3.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-200"
+            className={[
+              'mt-4 w-full rounded-2xl px-4 py-3.5 text-sm font-semibold transition',
+              buttonClassName,
+            ].join(' ')}
           >
             참여하기
           </button>

--- a/src/pages/main/ui/RoomCard.tsx
+++ b/src/pages/main/ui/RoomCard.tsx
@@ -1,4 +1,5 @@
 import { Clock3, MapPin, Users } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
 
 import type { MainRoom } from '../model/types';
 
@@ -41,17 +42,17 @@ const RoomCard = ({ room }: RoomCardProps) => {
 
   return (
     <article
-      className={[
+      className={cn(
         'overflow-hidden rounded-[28px] border shadow-[0_12px_30px_rgba(15,23,42,0.05)]',
         cardClassName,
-      ].join(' ')}
+      )}
     >
       <div className="p-5 md:p-6">
         <div className="min-w-0">
           <h2 className="text-[19px] font-bold tracking-[-0.03em] text-slate-900">{room.title}</h2>
 
           <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-500">
-            <span className={['rounded-md px-2 py-1 font-medium', badgeClassName].join(' ')}>
+            <span className={cn('rounded-md px-2 py-1 font-medium', badgeClassName)}>
               {badgeLabel}
             </span>
             <span className="rounded-md bg-slate-100 px-2 py-1 font-medium text-slate-600">
@@ -81,17 +82,17 @@ const RoomCard = ({ room }: RoomCardProps) => {
 
           <div className="mt-5 h-2 overflow-hidden rounded-full bg-slate-100">
             <div
-              className={['h-full rounded-full', progressClassName].join(' ')}
+              className={cn('h-full rounded-full', progressClassName)}
               style={{ width: `${progressPercent}%` }}
             />
           </div>
 
           <button
             type="button"
-            className={[
+            className={cn(
               'mt-4 w-full rounded-2xl px-4 py-3.5 text-sm font-semibold transition',
               buttonClassName,
-            ].join(' ')}
+            )}
           >
             참여하기
           </button>


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 메인 방 카드 구분 스타일 보정
- 메인 헤더 서비스명 노출 방식 수정

## ✨ 변경 사항 (Changes)

- 방 카드 왼쪽 세로 바 제거
- 카드 배경, 배지, 버튼 색으로 타입 구분 방식 개선
- 헤더 서비스명을 `점메추`로 명확하게 수정
- 보조 문구 추가로 서비스 의미 보강

## 📸 스크린샷 (Screenshots)

- 스크린샷 첨부

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 참고 사항 기재

## 🧐 이슈 (Related Issues)

- Closes #23
