### PR TITLE
refactor: (#42) 인증 저장소와 Axios 인증 헤더·401 처리 연동

### DIFF
--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.10'
+const PACKAGE_VERSION = '2.13.1'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,12 +1,12 @@
-//import MainPage from '@/pages/main/ui/MainPage';
-import MainPage from '@/pages/main/ui/MainPage';
+import { RouterProvider } from 'react-router';
+
 import QueryProvider from './queryProvider';
-import ProfilePage from '@/pages/ProfilePage';
+import router from './router';
 
 function App() {
   return (
     <QueryProvider>
-      <MainPage />
+      <RouterProvider router={router} />
     </QueryProvider>
   );
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,12 @@
+import { createBrowserRouter } from 'react-router';
+
+import MainPage from '@/pages/main/ui/MainPage';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <MainPage />,
+  },
+]);
+
+export default router;

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -24,6 +24,8 @@ const normalizeProfile = (profile: Partial<UserProfile> | null | undefined): Use
   profileImageUrl: typeof profile?.profileImageUrl === 'string' ? profile.profileImageUrl : '',
 });
 
+const NO_OP = () => {};
+
 export default function ProfilePage() {
   const queryClient = useQueryClient();
   const [profileDraft, setProfileDraft] = useState<UserProfile | null>(null);
@@ -112,7 +114,7 @@ export default function ProfilePage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-slate-50">
-        <MainHeader />
+        <MainHeader onLoginClick={NO_OP} />
         <main className="px-6 py-10 md:px-8">
           <section className="mx-auto flex w-full max-w-4xl items-center justify-center rounded-[32px] bg-white px-6 py-16 text-slate-500 shadow-sm sm:px-8 md:px-10">
             프로필을 불러오는 중...
@@ -125,7 +127,7 @@ export default function ProfilePage() {
   if (isError) {
     return (
       <div className="min-h-screen bg-slate-50">
-        <MainHeader />
+        <MainHeader onLoginClick={NO_OP} />
         <main className="px-6 py-10 md:px-8">
           <section className="mx-auto w-full max-w-4xl rounded-[32px] bg-white px-6 py-16 text-center shadow-sm sm:px-8 md:px-10">
             <p className="text-base text-rose-500">
@@ -147,7 +149,7 @@ export default function ProfilePage() {
 
   return (
     <div className="min-h-screen bg-slate-50">
-      <MainHeader />
+      <MainHeader onLoginClick={NO_OP} />
 
       <main className="px-6 py-10 md:px-8">
         <section className="mx-auto w-full max-w-4xl rounded-[32px] bg-white px-6 py-8 shadow-sm sm:px-8 md:px-10 md:py-10">

--- a/src/pages/main/ui/LoginModal.tsx
+++ b/src/pages/main/ui/LoginModal.tsx
@@ -1,4 +1,4 @@
-import { useId, useRef } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import { ArrowLeft, Eye, UsersRound } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useState } from 'react';
@@ -48,6 +48,23 @@ const LoginModal = ({ isOpen, onClose }: LoginModalProps) => {
       passwordConfirm: '',
     },
   });
+
+  useEffect(() => {
+    const dialogElement = dialogRef.current;
+
+    if (!dialogElement) {
+      return;
+    }
+
+    if (isOpen && !dialogElement.open) {
+      dialogElement.showModal();
+      return;
+    }
+
+    if (!isOpen && dialogElement.open) {
+      dialogElement.close();
+    }
+  }, [isOpen]);
 
   const handleClose = () => {
     loginForm.reset();

--- a/src/pages/main/ui/MainPage.tsx
+++ b/src/pages/main/ui/MainPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { mockRooms } from '../mocks/mockRooms';
 import MainHeader from './MainHeader';
 import MainHero from './MainHero';
 import LoginModal from './LoginModal';


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- `App.tsx`의 직접 페이지 렌더 구조를 제거하고, `app` 계층에 React Router 기반 엔트리 구조를 도입했습니다.
- `QueryProvider`와 `RouterProvider`의 배치 기준을 정리해, 이후 라우트 확장이 가능한 최소 bootstrap 상태를 만들었습니다.
- 이번 PR에서는 `/` 기본 라우트만 연결하고, `/profile` 라우트 등록은 후속 `#41`로 남겨뒀습니다.

## ✨ 변경 사항 (Changes)

- `src/app/router.tsx`를 추가해 `/` 기본 라우트를 `MainPage`에 연결
- `src/app/App.tsx`를 `QueryProvider + RouterProvider` 조립 포인트로 변경
- 기존 빌드 blocker 최소 정리
  - `LoginModal`의 `isOpen` prop을 실제 dialog 제어에 연결
  - `MainPage`의 unused import 제거
  - `ProfilePage`의 `MainHeader` 필수 prop 누락 보정
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- UI 스크린샷 없음
- `/` 경로에서 기존 메인 화면이 동일하게 렌더링되는 구조 변경 위주

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 이번 PR은 `app` 계층의 router root/bootstrap만 다룹니다.
- `/profile` 라우트 등록과 route table 분리는 후속 이슈 `#41`에서 진행합니다.
- 인증 가드, route meta, auth store 연동은 이번 범위에 포함하지 않습니다.
- 빌드 통과를 위해 기존 타입/unused 에러 3건을 최소 범위로 함께 정리했습니다.

## 🧐 이슈 (Related Issues)

- Closes #42
