### PR TITLE
refactor: (#41) 메인·프로필 페이지 라우트 테이블 분리

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,12 +1,6 @@
 import { createBrowserRouter } from 'react-router';
+import routes from './routes';
 
-import MainPage from '@/pages/main/ui/MainPage';
-
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <MainPage />,
-  },
-]);
+const router = createBrowserRouter(routes);
 
 export default router;

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,0 +1,15 @@
+import MainPage from '@/pages/main/ui/MainPage';
+import ProfilePage from '@/pages/ProfilePage';
+
+const routes = [
+  {
+    path: '/',
+    element: <MainPage />,
+  },
+  {
+    path: '/profile',
+    element: <ProfilePage />,
+  },
+];
+
+export default routes;

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -24,8 +24,6 @@ const normalizeProfile = (profile: Partial<UserProfile> | null | undefined): Use
   profileImageUrl: typeof profile?.profileImageUrl === 'string' ? profile.profileImageUrl : '',
 });
 
-const NO_OP = () => {};
-
 export default function ProfilePage() {
   const queryClient = useQueryClient();
   const [profileDraft, setProfileDraft] = useState<UserProfile | null>(null);
@@ -114,7 +112,7 @@ export default function ProfilePage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-slate-50">
-        <MainHeader onLoginClick={NO_OP} />
+        <MainHeader />
         <main className="px-6 py-10 md:px-8">
           <section className="mx-auto flex w-full max-w-4xl items-center justify-center rounded-[32px] bg-white px-6 py-16 text-slate-500 shadow-sm sm:px-8 md:px-10">
             프로필을 불러오는 중...
@@ -127,7 +125,7 @@ export default function ProfilePage() {
   if (isError) {
     return (
       <div className="min-h-screen bg-slate-50">
-        <MainHeader onLoginClick={NO_OP} />
+        <MainHeader />
         <main className="px-6 py-10 md:px-8">
           <section className="mx-auto w-full max-w-4xl rounded-[32px] bg-white px-6 py-16 text-center shadow-sm sm:px-8 md:px-10">
             <p className="text-base text-rose-500">
@@ -149,7 +147,7 @@ export default function ProfilePage() {
 
   return (
     <div className="min-h-screen bg-slate-50">
-      <MainHeader onLoginClick={NO_OP} />
+      <MainHeader />
 
       <main className="px-6 py-10 md:px-8">
         <section className="mx-auto w-full max-w-4xl rounded-[32px] bg-white px-6 py-8 shadow-sm sm:px-8 md:px-10 md:py-10">

--- a/src/pages/main/ui/MainHeader.tsx
+++ b/src/pages/main/ui/MainHeader.tsx
@@ -1,14 +1,15 @@
+import { Link } from 'react-router';
 import { LogIn, UsersRound } from 'lucide-react';
 
 interface MainHeaderProps {
-  onLoginClick: () => void;
+  onLoginClick?: () => void;
 }
 
 const MainHeader = ({ onLoginClick }: MainHeaderProps) => {
   return (
     <header className="border-b border-slate-200/80 bg-white/95 backdrop-blur">
       <div className="mx-auto flex h-[78px] w-full max-w-5xl items-center justify-between px-5 md:px-8">
-        <div className="flex items-center gap-3">
+        <Link to="/" className="flex items-center gap-3 rounded-2xl outline-none transition hover:opacity-90 focus-visible:ring-2 focus-visible:ring-indigo-200">
           <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 to-indigo-600 text-white shadow-[0_10px_24px_rgba(99,102,241,0.25)]">
             <UsersRound className="h-5 w-5" />
           </div>
@@ -20,16 +21,18 @@ const MainHeader = ({ onLoginClick }: MainHeaderProps) => {
               점심메이트 추천
             </span>
           </div>
-        </div>
+        </Link>
 
-        <button
-          type="button"
-          onClick={onLoginClick}
-          className="inline-flex items-center gap-2 rounded-2xl border border-indigo-200 bg-white px-4 py-2.5 text-sm font-semibold text-indigo-500 transition hover:bg-indigo-50"
-        >
-          <LogIn className="h-4 w-4" />
-          로그인
-        </button>
+        {onLoginClick ? (
+          <button
+            type="button"
+            onClick={onLoginClick}
+            className="inline-flex items-center gap-2 rounded-2xl border border-indigo-200 bg-white px-4 py-2.5 text-sm font-semibold text-indigo-500 transition hover:bg-indigo-50"
+          >
+            <LogIn className="h-4 w-4" />
+            로그인
+          </button>
+        ) : null}
       </div>
     </header>
   );


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- `app` 계층에서 메인/프로필 route table을 명시적으로 분리했습니다.
- `/`는 `MainPage`, `/profile`은 `ProfilePage`를 렌더링하도록 연결했습니다.
- 공통 header를 route 기반으로 최소 정리해, 브랜드 클릭 시 홈으로 이동하고 프로필 화면에서는 불필요한 로그인 버튼이 노출되지 않도록 맞췄습니다.

## ✨ 변경 사항 (Changes)

- `src/app/routes.tsx`를 추가해 `/`와 `/profile` route table 정의
- `src/app/router.tsx`를 route table 기반으로 단순화
- `src/pages/main/ui/MainHeader.tsx`에서 브랜드를 홈 링크로 변경하고 `onLoginClick`을 optional prop으로 정리
- `src/pages/ProfilePage.tsx`에서 임시 no-op handler 제거 후 route element로 사용 가능하게 정리
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 해당 PR은 라우트 구조 정리 중심으로, 별도 UI 변경 스크린샷은 없습니다.
- `/`와 `/profile` 경로가 각각 정상 렌더링되는 연결 작업 위주입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 라우트 테이블 정의는 `app`, 실제 route element는 `pages`에 두는 기준으로 정리했습니다.
- `/profile`은 이번 단계에서 공개 route로 두며, 인증 가드와 보호 라우트는 후속 이슈에서 다룹니다.
- 이번 PR에서는 새로운 내비게이션 설계를 추가하지 않고, 기존 공통 header를 route 기반으로 최소 정리하는 수준까지만 포함합니다.

## 🧐 이슈 (Related Issues)

- Closes #41
