### PR TITLE
chore: (#43) Axios 공통 인스턴스와 baseURL 정책 도입

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '',
+  timeout: 10000,
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  },
+});
+
+export default client;

--- a/src/shared/api/profile.ts
+++ b/src/shared/api/profile.ts
@@ -1,12 +1,12 @@
-import axios from 'axios';
 import type {
   GetMyProfileResponse,
   UpdateMyProfileRequest,
   UpdateMyProfileResponse,
 } from '@/shared/types/profile';
+import client from '@/shared/api/client';
 
 export async function getMyProfile(): Promise<GetMyProfileResponse> {
-  const response = await axios.get<GetMyProfileResponse>('/api/v1/users/me/profile');
+  const response = await client.get<GetMyProfileResponse>('/api/v1/users/me/profile');
 
   return response.data;
 }
@@ -14,7 +14,7 @@ export async function getMyProfile(): Promise<GetMyProfileResponse> {
 export async function updateMyProfile(
   payload: UpdateMyProfileRequest,
 ): Promise<UpdateMyProfileResponse> {
-  const response = await axios.patch<UpdateMyProfileResponse>(
+  const response = await client.patch<UpdateMyProfileResponse>(
     '/api/v1/users/me/profile',
     payload,
   );


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- `shared/api` 계층에 공통 Axios 인스턴스를 도입해 baseURL과 기본 HTTP 정책을 한 곳에 모았습니다.
- 기존 `profile` API는 axios 전역 객체 대신 공통 client를 사용하도록 정리했습니다.
- 이번 PR은 인증 헤더나 401 처리 없이, 공통 HTTP 인프라 기준만 고정하는 범위로 제한했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/client.ts`를 추가해 공통 Axios 인스턴스 생성
- `VITE_API_URL` 기반 baseURL, 기본 JSON 헤더, `timeout: 10000` 정책 적용
- `src/shared/api/profile.ts`를 공통 client 사용 구조로 전환
- 기존 profile API 함수 시그니처와 endpoint는 유지
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 해당 PR은 공통 HTTP 클라이언트 정리 중심으로, 별도 UI 변경 스크린샷은 없습니다.
- API 호출 기준과 baseURL 정책을 공통화하는 작업 위주입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 공통 Axios client는 `shared` 계층의 HTTP 인프라만 담당하며, 인증 상태는 관리하지 않습니다.
- 인증 헤더와 401 interceptor는 후속 `#39`에서 연결합니다.
- API endpoint path(`/api/v1/...`)는 각 API 모듈에서 계속 관리하고, 공통 client는 baseURL/기본 옵션만 담당합니다.

## 🧐 이슈 (Related Issues)

- Closes #43
