### PR TITLE
feat: (#38) 인증 세션 저장소 기본 구조 도입

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,11 +1,13 @@
 import { RouterProvider } from 'react-router';
 
+import AuthSessionBootstrap from './authSessionBootstrap';
 import QueryProvider from './queryProvider';
 import router from './router';
 
 function App() {
   return (
     <QueryProvider>
+      <AuthSessionBootstrap />
       <RouterProvider router={router} />
     </QueryProvider>
   );

--- a/src/app/authSessionBootstrap.tsx
+++ b/src/app/authSessionBootstrap.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { authSessionSelectors, useAuthSessionStore } from './authSessionStore';
+
+const AuthSessionBootstrap = () => {
+  const hasHydrated = useAuthSessionStore(authSessionSelectors.hasHydrated);
+
+  useEffect(() => {
+    if (!hasHydrated) {
+      void useAuthSessionStore.persist.rehydrate();
+    }
+  }, [hasHydrated]);
+
+  return null;
+};
+
+export default AuthSessionBootstrap;

--- a/src/app/authSessionStore.ts
+++ b/src/app/authSessionStore.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+const AUTH_SESSION_STORAGE_KEY = 'lunchmate-auth-session';
+
+interface AuthSessionState {
+  accessToken: string | null;
+  hasHydrated: boolean;
+  setAccessToken: (accessToken: string) => void;
+  clearAccessToken: () => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
+}
+
+export const useAuthSessionStore = create<AuthSessionState>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      hasHydrated: false,
+      setAccessToken: (accessToken) => set({ accessToken }),
+      clearAccessToken: () => set({ accessToken: null }),
+      setHasHydrated: (hasHydrated) => set({ hasHydrated }),
+    }),
+    {
+      name: AUTH_SESSION_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+      }),
+      skipHydration: true,
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
+    },
+  ),
+);
+
+export const authSessionSelectors = {
+  accessToken: (state: AuthSessionState) => state.accessToken,
+  hasHydrated: (state: AuthSessionState) => state.hasHydrated,
+  isAuthenticated: (state: AuthSessionState) => Boolean(state.accessToken),
+};
+
+export const getAccessToken = () =>
+  authSessionSelectors.accessToken(useAuthSessionStore.getState());
+
+export const isAuthenticated = () =>
+  authSessionSelectors.isAuthenticated(useAuthSessionStore.getState());
+
+export const setAuthAccessToken = (accessToken: string) =>
+  useAuthSessionStore.getState().setAccessToken(accessToken);
+
+export const clearAuthSession = () => useAuthSessionStore.getState().clearAccessToken();


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- `app` 계층에 인증 세션 전역 상태를 관리하는 zustand store를 도입했습니다.
- `accessToken` 저장/초기화와 로그인 상태 파생값을 공통 인터페이스로 정리했습니다.
- 앱 시작 시 persist rehydrate가 수행되도록 bootstrap을 연결해, 후속 Axios interceptor와 보호 라우트가 같은 세션 상태를 참조할 수 있는 기반을 만들었습니다.

## ✨ 변경 사항 (Changes)

- `src/app/authSessionStore.ts`를 추가해 `accessToken`, `hasHydrated`, 액션, selector, 외부 helper 정의
- zustand persist를 사용해 auth session을 `localStorage`에 저장하고 복원 정책 적용
- `src/app/authSessionBootstrap.tsx`를 추가해 앱 시작 시 rehydrate 수행
- `src/app/App.tsx`에 auth session bootstrap 연결
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 해당 PR은 인증 세션 저장소 bootstrap 중심으로, 별도 UI 변경 스크린샷은 없습니다.
- 앱 전역에서 재사용 가능한 auth session 상태 기반을 만드는 작업 위주입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- auth session store는 `shared`가 아니라 `app` 계층에서 관리합니다.
- 이번 단계에서는 `accessToken` 저장/초기화와 hydration까지만 포함하고, 로그인 API 연결·refresh token·재발급·401 처리·보호 라우트는 후속 이슈에서 다룹니다.
- 후속 Axios/라우트 가드는 `getAccessToken`, `isAuthenticated`, `clearAuthSession` 같은 공개 helper를 통해 동일한 store를 참조하는 기준으로 이어집니다.

## 🧐 이슈 (Related Issues)

- Closes #38
