### PR TITLE
feat: (#39) 인증 저장소와 Axios 인증 헤더·401 처리 연동

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { clearAuthSession, getAccessToken } from '@/app/authSessionStore';
 
 const client = axios.create({
   baseURL: import.meta.env.VITE_API_URL || '',
@@ -8,5 +9,28 @@ const client = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+client.interceptors.request.use((config) => {
+  const accessToken = getAccessToken();
+
+  if (accessToken) {
+    config.headers.set('Authorization', `Bearer ${accessToken}`);
+  } else {
+    config.headers.delete('Authorization');
+  }
+
+  return config;
+});
+
+client.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      clearAuthSession();
+    }
+
+    return Promise.reject(error);
+  },
+);
 
 export default client;


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- `app` 계층의 auth session store와 `shared` 계층의 공통 Axios client를 연동했습니다.
- 요청 시 저장된 access token이 있으면 `Authorization` 헤더를 자동으로 부착하도록 정리했습니다.
- 401 응답이 오면 공통으로 인증 세션을 초기화해, 이후 보호 라우트와 로그인 흐름이 같은 기준을 사용할 수 있도록 만들었습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/client.ts`에 request interceptor를 추가해 `getAccessToken()` 기반 Authorization 헤더 부착
- 토큰이 없는 경우 Authorization 헤더 제거 처리
- `src/shared/api/client.ts`에 response interceptor를 추가해 401 응답 시 `clearAuthSession()` 수행
- 기존 profile API는 공통 client를 계속 사용하며 새 인증 정책 아래에서도 동작 가능한 구조 유지
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 해당 PR은 인증 저장소와 HTTP 클라이언트 연동 중심으로, 별도 UI 변경 스크린샷은 없습니다.
- 공통 인증 헤더 부착과 401 세션 초기화 기준을 정리하는 작업 위주입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 인증 세션 상태는 `app` 계층 store가 관리하고, Axios client는 그 상태를 읽기만 합니다.
- 이번 단계에서는 401 발생 시 세션 초기화까지만 포함하고, 어느 화면으로 이동할지는 후속 로그인/보호 라우트 이슈에서 다룹니다.
- refresh token, 재발급, 로그인 API 연결은 이번 범위에 포함하지 않습니다.

## 🧐 이슈 (Related Issues)

- Closes #39
