### PR TITLE
refactor: (#55) Main lunch 기능 UI 구조 분리

### DIFF
--- a/src/pages/main/model/types.ts
+++ b/src/pages/main/model/types.ts
@@ -1,21 +1,5 @@
 export type MainTab = 'ROOM' | 'LUNCH' | 'RANKING' | 'BOARD';
 
-export interface MainLunchMenu {
-  id: number;
-  cafeteriaName: string;
-  mealTime: string;
-  title: string;
-  description: string;
-  detailDescription: string;
-  price: number;
-  calorie: number;
-  sideMenus: string[];
-  location: string;
-  spicyLevel: '순한맛' | '보통맛' | '매운맛';
-  likedCount: number;
-  dislikedCount: number;
-}
-
 export interface MainRankingItem {
   id: number;
   rank: number;

--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -1,7 +1,7 @@
 import { Plus } from 'lucide-react';
 import type { MainTab } from '../../model/types';
 import MainBoardSection from '../MainBoardSection';
-import MainLunchMenuSection from '../MainLunchMenuSection';
+import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../MainRankingSection';
 import { mockRooms } from '../room/mockRooms';
 import RoomCard from '../room/RoomCard';

--- a/src/pages/main/ui/lunch/MainLunchMenuSection.tsx
+++ b/src/pages/main/ui/lunch/MainLunchMenuSection.tsx
@@ -2,7 +2,7 @@ import { Flame, MapPin, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { useState } from 'react';
 import { cn } from '@/shared/lib/utils';
 
-import { mockLunchMenus } from '../mocks/mockLunchMenus';
+import { mockLunchMenus } from './mockLunchMenus';
 
 const KRW_NUMBER_FORMAT = new Intl.NumberFormat('ko-KR');
 

--- a/src/pages/main/ui/lunch/mockLunchMenus.ts
+++ b/src/pages/main/ui/lunch/mockLunchMenus.ts
@@ -1,4 +1,4 @@
-import type { MainLunchMenu } from '../model/types';
+import type { MainLunchMenu } from './types';
 
 export const mockLunchMenus: MainLunchMenu[] = [
   {

--- a/src/pages/main/ui/lunch/types.ts
+++ b/src/pages/main/ui/lunch/types.ts
@@ -1,0 +1,15 @@
+export interface MainLunchMenu {
+  id: number;
+  cafeteriaName: string;
+  mealTime: string;
+  title: string;
+  description: string;
+  detailDescription: string;
+  price: number;
+  calorie: number;
+  sideMenus: string[];
+  location: string;
+  spicyLevel: '순한맛' | '보통맛' | '매운맛';
+  likedCount: number;
+  dislikedCount: number;
+}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- lunch 관련 UI, mock, 타입을 `pages/main/ui/lunch` 아래로 분리했습니다.
- `MainLunchMenuSection`, `mockLunchMenus`, `MainLunchMenu` 타입 소유권을 lunch 기능 기준으로 정리했습니다.
- 메인 레이아웃은 lunch 폴더를 참조하도록 import만 정리했고, 기존 LUNCH 탭 동작은 유지했습니다.

## ✨ 변경 사항 (Changes)

- `src/pages/main/ui/lunch/...` 아래로 lunch UI 파일 이동
- `src/pages/main/ui/lunch/mockLunchMenus.ts`, `src/pages/main/ui/lunch/types.ts` 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`의 lunch import 경로 정리
- 공용 `src/pages/main/model/types.ts`에서는 `MainTab`만 유지하고 `MainLunchMenu` 제거
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 해당 PR은 lunch 기능 UI 구조 정리 중심으로, 별도 UI 변경 스크린샷은 없습니다.
- LUNCH 탭 렌더를 유지한 채 내부 lunch 구조를 분리하는 작업 위주입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 이번 PR은 lunch 기능 UI 구조와 import 정리만 다룹니다.
- 실제 학식 API 연동, 좋아요/싫어요, 랭킹 구현은 포함하지 않습니다.
- ranking/board/auth 분리는 후속 이슈 `#56`~`#58`에서 계속 정리합니다.

## 🧐 이슈 (Related Issues)

- Closes #55
