### PR TITLE
refactor: (#56) Main ranking 기능 UI 구조 분리

### DIFF
--- a/src/pages/main/model/types.ts
+++ b/src/pages/main/model/types.ts
@@ -1,15 +1,5 @@
 export type MainTab = 'ROOM' | 'LUNCH' | 'RANKING' | 'BOARD';
 
-export interface MainRankingItem {
-  id: number;
-  rank: number;
-  title: string;
-  cafeteriaName: string;
-  mealTime: string;
-  likedCount: number;
-  changeText: string;
-}
-
 export interface MainBoardPost {
   id: number;
   category: 'FREE' | 'REVIEW' | 'INFO' | 'TALK';

--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -2,7 +2,7 @@ import { Plus } from 'lucide-react';
 import type { MainTab } from '../../model/types';
 import MainBoardSection from '../MainBoardSection';
 import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
-import MainRankingSection from '../MainRankingSection';
+import MainRankingSection from '../ranking/MainRankingSection';
 import { mockRooms } from '../room/mockRooms';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';

--- a/src/pages/main/ui/ranking/MainRankingSection.tsx
+++ b/src/pages/main/ui/ranking/MainRankingSection.tsx
@@ -1,6 +1,6 @@
 import { Medal, TrendingUp } from 'lucide-react';
 
-import { mockRankings } from '../mocks/mockRankings';
+import { mockRankings } from './mockRankings';
 
 const rankStyleMap = {
   1: 'from-amber-400 to-orange-400',
@@ -20,7 +20,8 @@ const MainRankingSection = () => {
             <div
               className={[
                 'flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br text-white shadow-[0_10px_24px_rgba(15,23,42,0.12)]',
-                rankStyleMap[mockRanking.rank as keyof typeof rankStyleMap] ?? 'from-indigo-400 to-indigo-500',
+                rankStyleMap[mockRanking.rank as keyof typeof rankStyleMap] ??
+                  'from-indigo-400 to-indigo-500',
               ].join(' ')}
             >
               <Medal className="h-6 w-6" />

--- a/src/pages/main/ui/ranking/mockRankings.ts
+++ b/src/pages/main/ui/ranking/mockRankings.ts
@@ -1,4 +1,4 @@
-import type { MainRankingItem } from '../model/types';
+import type { MainRankingItem } from './types';
 
 export const mockRankings: MainRankingItem[] = [
   {

--- a/src/pages/main/ui/ranking/types.ts
+++ b/src/pages/main/ui/ranking/types.ts
@@ -1,0 +1,9 @@
+export interface MainRankingItem {
+  id: number;
+  rank: number;
+  title: string;
+  cafeteriaName: string;
+  mealTime: string;
+  likedCount: number;
+  changeText: string;
+}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ranking 관련 UI, mock, 타입을 `pages/main/ui/ranking` 아래로 분리했습니다.
- `MainRankingSection`, `mockRankings`, `MainRankingItem` 소유권을 ranking 기능 기준으로 정리했습니다.
- 메인 레이아웃은 ranking 폴더를 참조하도록 import만 정리했고, 기존 RANKING 탭 동작은 유지했습니다.

## ✨ 변경 사항 (Changes)

- `src/pages/main/ui/ranking/...` 아래로 ranking UI 파일 이동
- `src/pages/main/ui/ranking/mockRankings.ts`, `src/pages/main/ui/ranking/types.ts` 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`의 ranking import 경로 정리
- 공용 `src/pages/main/model/types.ts`에서는 `MainTab`, board 타입만 유지하고 `MainRankingItem` 제거
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 해당 PR은 ranking 기능 UI 구조 정리 중심으로, 별도 UI 변경 스크린샷은 없습니다.
- RANKING 탭 렌더를 유지한 채 내부 ranking 구조를 분리하는 작업 위주입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 이번 PR은 ranking 기능 UI 구조와 import 정리만 다룹니다.
- 실제 랭킹 API 연동과 데이터 갱신 로직은 포함하지 않습니다.
- board/auth 분리는 후속 이슈 `#57`~`#58`에서 계속 정리합니다.

## 🧐 이슈 (Related Issues)

- Closes #56
