### PR TITLE
feat: (#66) 방 목록 조회 연결

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -7,8 +7,7 @@ import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
 import type { MainRoom } from '../room/types';
-import type { RoomListItemResponse } from '@/shared/api/rooms/rooms';
-import { roomsListQueryOptions } from '@/shared/api/rooms/roomsQueries';
+import { roomsListQueryOptions, type RoomListItemResponse } from '@/shared/api/rooms';
 
 interface MainTabSectionProps {
   activeTab: MainTab;

--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -1,11 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import type { MainTab } from '../../model/types';
 import MainBoardSection from '../board/MainBoardSection';
 import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
-import { mockRooms } from '../room/mockRooms';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
+import type { MainRoom } from '../room/types';
+import type { RoomListItemResponse } from '@/shared/api/rooms/rooms';
+import { roomsListQueryOptions } from '@/shared/api/rooms/roomsQueries';
 
 interface MainTabSectionProps {
   activeTab: MainTab;
@@ -19,8 +22,43 @@ const tabDescriptionMap: Record<MainTab, string> = {
   BOARD: '자유게시판에서 점심메이트와 가볍게 소통해보세요.',
 };
 
+const toMainRoomType = (roomType: RoomListItemResponse['roomType']): MainRoom['roomType'] => {
+  if (roomType === 'MALE' || roomType === 'FEMALE') {
+    return roomType;
+  }
+
+  return 'MIXED';
+};
+
+const formatLunchAt = (lunchAt: string): string => {
+  const timeMatch = lunchAt.match(/(?:T|\s)?(\d{2}:\d{2})/);
+
+  if (timeMatch) {
+    return timeMatch[1];
+  }
+
+  return lunchAt;
+};
+
+const toMainRoom = (room: RoomListItemResponse): MainRoom => ({
+  id: room.id,
+  title: room.title,
+  roomType: toMainRoomType(room.roomType),
+  minAge: room.minAge,
+  maxAge: room.maxAge,
+  currentCount: room.currentCount,
+  capacity: room.maxMembersCount,
+  place: room.place,
+  lunchAt: formatLunchAt(room.lunchAt),
+});
+
 const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) => {
   const isRoomTab = activeTab === 'ROOM';
+  const { data, isLoading, isError, error } = useQuery({
+    ...roomsListQueryOptions(),
+    enabled: isRoomTab,
+  });
+  const rooms = data?.items.map(toMainRoom) ?? [];
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -44,13 +82,32 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
         ) : null}
       </div>
 
-      {isRoomTab ? <RoomSummary roomCount={mockRooms.length} /> : null}
+      {isRoomTab && !isLoading && !isError ? <RoomSummary roomCount={rooms.length} /> : null}
 
       {activeTab === 'ROOM' ? (
         <div className="space-y-4 md:space-y-5">
-          {mockRooms.map((room) => (
-            <RoomCard key={room.id} room={room} />
-          ))}
+          {isLoading ? (
+            <section className="rounded-[28px] border border-slate-200/80 bg-white px-6 py-10 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+              점심 방을 불러오는 중...
+            </section>
+          ) : null}
+
+          {isError ? (
+            <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-10 text-center text-sm text-rose-600 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+              점심 방을 불러오지 못했어요.
+              {error instanceof Error ? ` ${error.message}` : ''}
+            </section>
+          ) : null}
+
+          {!isLoading && !isError && rooms.length === 0 ? (
+            <section className="rounded-[28px] border border-slate-200/80 bg-white px-6 py-10 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+              아직 열려 있는 점심 방이 없어요.
+            </section>
+          ) : null}
+
+          {!isLoading && !isError
+            ? rooms.map((room) => <RoomCard key={room.id} room={room} />)
+            : null}
         </div>
       ) : null}
 

--- a/src/shared/api/rooms/index.ts
+++ b/src/shared/api/rooms/index.ts
@@ -1,0 +1,3 @@
+export type { GetRoomsResponse, RoomListItemResponse } from './rooms';
+export { getRooms } from './rooms';
+export { roomsListQueryOptions } from './roomsQueries';

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -1,0 +1,23 @@
+import client from '@/shared/api/client';
+
+export interface RoomListItemResponse {
+  id: number;
+  title: string;
+  roomType: 'MALE' | 'FEMALE' | 'ANY' | string;
+  maxMembersCount: number;
+  minAge: number;
+  maxAge: number;
+  place: string;
+  lunchAt: string;
+  currentCount: number;
+}
+
+export interface GetRoomsResponse {
+  items: RoomListItemResponse[];
+}
+
+export async function getRooms(): Promise<GetRoomsResponse> {
+  const response = await client.get<GetRoomsResponse>('/api/v1/rooms');
+
+  return response.data;
+}

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -1,4 +1,4 @@
-import client from '@/shared/api/client';
+import client from '../client';
 
 export interface RoomListItemResponse {
   id: number;

--- a/src/shared/api/rooms/roomsQueries.ts
+++ b/src/shared/api/rooms/roomsQueries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from '@tanstack/react-query';
-import { getRooms } from '@/shared/api/rooms/rooms';
+import { getRooms } from './rooms';
 
 export const roomsListQueryOptions = () =>
   queryOptions({

--- a/src/shared/api/rooms/roomsQueries.ts
+++ b/src/shared/api/rooms/roomsQueries.ts
@@ -1,0 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getRooms } from '@/shared/api/rooms/rooms';
+
+export const roomsListQueryOptions = () =>
+  queryOptions({
+    queryKey: ['rooms', 'list'],
+    queryFn: getRooms,
+  });


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 탭을 mock 기반 목록 렌더에서 실제 API 조회 기반으로 전환했습니다.
- `react-query`로 room 목록을 조회하고, 목록 응답을 기존 `RoomCard` UI에 맞게 매핑했습니다.
- 이번 PR은 목록 조회만 다루며, 필터/상세/생성/참여/관리 액션은 후속 이슈로 분리합니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts` 추가
- `src/shared/api/rooms/roomsQueries.ts` 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`에서 `mockRooms` 제거 후 실제 목록 조회 연결
- loading / error / empty 상태 UI 추가
- API 응답의 `roomType`, `maxMembersCount`, `lunchAt`를 기존 화면 타입에 맞게 매핑
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 해당 PR은 구조/연결 중심 작업이라 별도 UI 변경 스크린샷은 없습니다.
- ROOM 탭이 API 기준으로 목록, 빈 상태, 에러 상태를 처리하도록 바뀌는 작업 위주입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 현재 `GET /api/v1/rooms` 응답은 `items[]` 기준으로 가정하고 있습니다.
- `roomType: ANY`는 화면에서는 `MIXED`로 매핑합니다.
- `lunchAt`은 UI 표시용으로 `HH:mm`만 추출합니다.
- 필터는 `#67`, 상세는 `#68`, 생성은 `#69`에서 이어서 처리합니다.
- 기존 `.gitkeep`는 그대로 두고 room API 파일만 추가한 상태입니다.

## 🧐 이슈 (Related Issues)

- Closes #66
