### PR TITLE
feat: (#67) 방 필터 / query parameter 연결

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import type { MainTab } from '../../model/types';
@@ -7,12 +8,23 @@ import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
 import type { MainRoom } from '../room/types';
-import type { RoomListItemResponse } from '@/shared/api/rooms/rooms';
+import type { RoomListFilters, RoomListItemResponse } from '@/shared/api/rooms/rooms';
 import { roomsListQueryOptions } from '@/shared/api/rooms/roomsQueries';
+import { cn } from '@/shared/lib/utils';
 
 interface MainTabSectionProps {
   activeTab: MainTab;
   onCreateRoomClick: () => void;
+}
+
+type RoomTypeFilter = 'ALL' | 'ANY' | 'MALE' | 'FEMALE';
+type RoomStatusFilter = 'ALL' | 'OPEN' | 'FULL' | 'CLOSE';
+
+interface RoomFilterState {
+  roomType: RoomTypeFilter;
+  status: RoomStatusFilter;
+  minAge: string;
+  maxAge: string;
 }
 
 const tabDescriptionMap: Record<MainTab, string> = {
@@ -21,6 +33,27 @@ const tabDescriptionMap: Record<MainTab, string> = {
   RANKING: '좋아요를 많이 받은 인기 학식 메뉴를 둘러보세요.',
   BOARD: '자유게시판에서 점심메이트와 가볍게 소통해보세요.',
 };
+
+const INITIAL_ROOM_FILTER_STATE: RoomFilterState = {
+  roomType: 'ALL',
+  status: 'ALL',
+  minAge: '',
+  maxAge: '',
+};
+
+const roomTypeFilterOptions: Array<{ label: string; value: RoomTypeFilter }> = [
+  { label: '전체', value: 'ALL' },
+  { label: '혼성', value: 'ANY' },
+  { label: '남성', value: 'MALE' },
+  { label: '여성', value: 'FEMALE' },
+];
+
+const roomStatusFilterOptions: Array<{ label: string; value: RoomStatusFilter }> = [
+  { label: '전체', value: 'ALL' },
+  { label: '모집중', value: 'OPEN' },
+  { label: '마감임박/정원도달', value: 'FULL' },
+  { label: '종료', value: 'CLOSE' },
+];
 
 const toMainRoomType = (roomType: RoomListItemResponse['roomType']): MainRoom['roomType'] => {
   if (roomType === 'MALE' || roomType === 'FEMALE') {
@@ -52,10 +85,33 @@ const toMainRoom = (room: RoomListItemResponse): MainRoom => ({
   lunchAt: formatLunchAt(room.lunchAt),
 });
 
+const parseAgeFilter = (value: string): number | undefined => {
+  if (value.trim() === '') {
+    return undefined;
+  }
+
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue)) {
+    return undefined;
+  }
+
+  return parsedValue;
+};
+
+const toRoomListFilters = (roomFilterState: RoomFilterState): RoomListFilters => ({
+  roomType: roomFilterState.roomType === 'ALL' ? undefined : roomFilterState.roomType,
+  status: roomFilterState.status === 'ALL' ? undefined : roomFilterState.status,
+  minAge: parseAgeFilter(roomFilterState.minAge),
+  maxAge: parseAgeFilter(roomFilterState.maxAge),
+});
+
 const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) => {
   const isRoomTab = activeTab === 'ROOM';
+  const [roomFilterState, setRoomFilterState] = useState<RoomFilterState>(INITIAL_ROOM_FILTER_STATE);
+  const roomFilters = toRoomListFilters(roomFilterState);
   const { data, isLoading, isError, error } = useQuery({
-    ...roomsListQueryOptions(),
+    ...roomsListQueryOptions(roomFilters),
     enabled: isRoomTab,
   });
   const rooms = data?.items.map(toMainRoom) ?? [];
@@ -81,6 +137,100 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
           </button>
         ) : null}
       </div>
+
+      {isRoomTab ? (
+        <section className="rounded-[28px] border border-slate-200/80 bg-white px-5 py-5 shadow-[0_12px_30px_rgba(15,23,42,0.05)] md:px-6">
+          <div className="space-y-4">
+            <div>
+              <p className="text-sm font-semibold text-slate-700">방 구분</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {roomTypeFilterOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() =>
+                      setRoomFilterState((current) => ({
+                        ...current,
+                        roomType: option.value,
+                      }))
+                    }
+                    className={cn(
+                      'rounded-2xl px-4 py-2.5 text-sm font-semibold transition',
+                      roomFilterState.roomType === option.value
+                        ? 'bg-slate-900 text-white'
+                        : 'border border-slate-200 bg-white text-slate-600 hover:bg-slate-50',
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <p className="text-sm font-semibold text-slate-700">모집 상태</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {roomStatusFilterOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() =>
+                      setRoomFilterState((current) => ({
+                        ...current,
+                        status: option.value,
+                      }))
+                    }
+                    className={cn(
+                      'rounded-2xl px-4 py-2.5 text-sm font-semibold transition',
+                      roomFilterState.status === option.value
+                        ? 'bg-slate-900 text-white'
+                        : 'border border-slate-200 bg-white text-slate-600 hover:bg-slate-50',
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-semibold text-slate-700">최소 나이</span>
+                <input
+                  type="number"
+                  min="0"
+                  value={roomFilterState.minAge}
+                  onChange={(event) =>
+                    setRoomFilterState((current) => ({
+                      ...current,
+                      minAge: event.target.value,
+                    }))
+                  }
+                  placeholder="예: 20"
+                  className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+                />
+              </label>
+
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-semibold text-slate-700">최대 나이</span>
+                <input
+                  type="number"
+                  min="0"
+                  value={roomFilterState.maxAge}
+                  onChange={(event) =>
+                    setRoomFilterState((current) => ({
+                      ...current,
+                      maxAge: event.target.value,
+                    }))
+                  }
+                  placeholder="예: 24"
+                  className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+                />
+              </label>
+            </div>
+          </div>
+        </section>
+      ) : null}
 
       {isRoomTab && !isLoading && !isError ? <RoomSummary roomCount={rooms.length} /> : null}
 

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -16,8 +16,22 @@ export interface GetRoomsResponse {
   items: RoomListItemResponse[];
 }
 
-export async function getRooms(): Promise<GetRoomsResponse> {
-  const response = await client.get<GetRoomsResponse>('/api/v1/rooms');
+export interface RoomListFilters {
+  roomType?: 'ANY' | 'MALE' | 'FEMALE';
+  status?: 'OPEN' | 'FULL' | 'CLOSE';
+  minAge?: number;
+  maxAge?: number;
+}
+
+export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsResponse> {
+  const response = await client.get<GetRoomsResponse>('/api/v1/rooms', {
+    params: {
+      roomType: filters.roomType,
+      status: filters.status,
+      minAge: filters.minAge,
+      maxAge: filters.maxAge,
+    },
+  });
 
   return response.data;
 }

--- a/src/shared/api/rooms/roomsQueries.ts
+++ b/src/shared/api/rooms/roomsQueries.ts
@@ -1,8 +1,8 @@
 import { queryOptions } from '@tanstack/react-query';
-import { getRooms } from '@/shared/api/rooms/rooms';
+import { getRooms, type RoomListFilters } from '@/shared/api/rooms/rooms';
 
-export const roomsListQueryOptions = () =>
+export const roomsListQueryOptions = (filters: RoomListFilters = {}) =>
   queryOptions({
-    queryKey: ['rooms', 'list'],
-    queryFn: getRooms,
+    queryKey: ['rooms', 'list', filters],
+    queryFn: () => getRooms(filters),
   });


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 탭에 필터 UI를 추가하고, 필터 state를 실제 목록 조회 query parameter와 연결했습니다.
- `roomType`, `status`, `minAge`, `maxAge`를 react-query queryKey/queryFn에 반영해 필터 변경 시 자동 재조회되도록 구성했습니다.
- 이번 PR은 필터와 query wiring만 다루며, 상세/생성/참여/관리 액션은 후속 이슈로 분리합니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts`에 `RoomListFilters` 추가 및 query params 지원
- `src/shared/api/rooms/roomsQueries.ts`를 `roomsListQueryOptions(filters)` 형태로 변경
- `src/pages/main/ui/layout/MainTabSection.tsx`에 ROOM 필터 UI 추가
- 방 구분 / 모집 상태 / 나이 범위 필터 state 추가
- 필터 변경 시 목록 자동 재조회 연결
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- ROOM 탭 상단에 필터 UI가 추가되고, 선택값이 목록 조회 요청에 반영되는 작업 위주입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- backend 계약은 `GET /api/v1/rooms`의 `roomType?`, `status?`, `minAge?`, `maxAge?` 기준을 사용합니다.
- `ALL` 상태는 query parameter를 보내지 않습니다.
- `roomType`은 query에서는 `ANY | MALE | FEMALE`, 화면 표시에서는 기존 `MIXED | MALE | FEMALE` 매핑을 유지합니다.
- `minAge`, `maxAge`는 문자열 state로 유지하고 요청 직전에 숫자로 정제합니다.
- `minAge > maxAge`에 대한 별도 validation UI는 이번 PR 범위에 포함하지 않습니다.
- 상세는 `#68`, 생성은 `#69`에서 이어서 처리합니다.

## 🧐 이슈 (Related Issues)

- Closes #67
