### PR TITLE
feat: (#68) 방 상세 조회 연결

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Plus } from 'lucide-react';
+import { Clock3, MapPin, Plus, Users } from 'lucide-react';
 import type { MainTab } from '../../model/types';
 import MainBoardSection from '../board/MainBoardSection';
 import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
@@ -8,8 +8,8 @@ import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
 import type { MainRoom } from '../room/types';
-import type { RoomListFilters, RoomListItemResponse } from '@/shared/api/rooms/rooms';
-import { roomsListQueryOptions } from '@/shared/api/rooms/roomsQueries';
+import type { RoomDetailResponse, RoomListFilters, RoomListItemResponse } from '@/shared/api/rooms/rooms';
+import { roomDetailQueryOptions, roomsListQueryOptions } from '@/shared/api/rooms/roomsQueries';
 import { cn } from '@/shared/lib/utils';
 
 interface MainTabSectionProps {
@@ -55,6 +55,36 @@ const roomStatusFilterOptions: Array<{ label: string; value: RoomStatusFilter }>
   { label: '종료', value: 'CLOSE' },
 ];
 
+const detailRoomTypeStyleMap = {
+  MALE: {
+    badgeClassName: 'bg-sky-100 text-sky-700',
+    badgeLabel: '남성만',
+  },
+  FEMALE: {
+    badgeClassName: 'bg-rose-100 text-rose-700',
+    badgeLabel: '여성만',
+  },
+  MIXED: {
+    badgeClassName: 'bg-indigo-100 text-indigo-700',
+    badgeLabel: '혼성',
+  },
+} as const;
+
+const detailRoomStatusStyleMap = {
+  OPEN: {
+    badgeClassName: 'bg-emerald-100 text-emerald-700',
+    badgeLabel: '모집중',
+  },
+  FULL: {
+    badgeClassName: 'bg-amber-100 text-amber-700',
+    badgeLabel: '정원도달',
+  },
+  CLOSE: {
+    badgeClassName: 'bg-slate-200 text-slate-700',
+    badgeLabel: '종료',
+  },
+} as const;
+
 const toMainRoomType = (roomType: RoomListItemResponse['roomType']): MainRoom['roomType'] => {
   if (roomType === 'MALE' || roomType === 'FEMALE') {
     return roomType;
@@ -85,6 +115,24 @@ const toMainRoom = (room: RoomListItemResponse): MainRoom => ({
   lunchAt: formatLunchAt(room.lunchAt),
 });
 
+const toDetailRoomType = (roomType: RoomDetailResponse['roomType']): MainRoom['roomType'] => {
+  if (roomType === 'MALE' || roomType === 'FEMALE') {
+    return roomType;
+  }
+
+  return 'MIXED';
+};
+
+const toDetailRoomStatus = (
+  status: RoomDetailResponse['status'],
+): keyof typeof detailRoomStatusStyleMap => {
+  if (status === 'OPEN' || status === 'FULL' || status === 'CLOSE') {
+    return status;
+  }
+
+  return 'OPEN';
+};
+
 const parseAgeFilter = (value: string): number | undefined => {
   if (value.trim() === '') {
     return undefined;
@@ -109,12 +157,39 @@ const toRoomListFilters = (roomFilterState: RoomFilterState): RoomListFilters =>
 const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) => {
   const isRoomTab = activeTab === 'ROOM';
   const [roomFilterState, setRoomFilterState] = useState<RoomFilterState>(INITIAL_ROOM_FILTER_STATE);
+  const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
   const roomFilters = toRoomListFilters(roomFilterState);
   const { data, isLoading, isError, error } = useQuery({
     ...roomsListQueryOptions(roomFilters),
     enabled: isRoomTab,
   });
+  const {
+    data: roomDetail,
+    isLoading: isRoomDetailLoading,
+    isError: isRoomDetailError,
+    error: roomDetailError,
+  } = useQuery({
+    ...roomDetailQueryOptions(selectedRoomId ?? 0),
+    enabled: isRoomTab && selectedRoomId !== null,
+  });
   const rooms = data?.items.map(toMainRoom) ?? [];
+
+  useEffect(() => {
+    if (!isRoomTab) {
+      return;
+    }
+
+    if (rooms.length === 0) {
+      setSelectedRoomId(null);
+      return;
+    }
+
+    const hasSelectedRoom = selectedRoomId !== null && rooms.some((room) => room.id === selectedRoomId);
+
+    if (!hasSelectedRoom) {
+      setSelectedRoomId(rooms[0].id);
+    }
+  }, [isRoomTab, rooms, selectedRoomId]);
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -256,9 +331,97 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
           ) : null}
 
           {!isLoading && !isError
-            ? rooms.map((room) => <RoomCard key={room.id} room={room} />)
+            ? rooms.map((room) => (
+                <RoomCard
+                  key={room.id}
+                  room={room}
+                  isSelected={selectedRoomId === room.id}
+                  onClick={() => setSelectedRoomId(room.id)}
+                />
+              ))
             : null}
         </div>
+      ) : null}
+
+      {isRoomTab && selectedRoomId !== null && !isLoading && !isError ? (
+        <>
+          {isRoomDetailLoading ? (
+            <article className="rounded-[32px] border border-slate-200/80 bg-white px-6 py-10 text-center text-sm text-slate-500 shadow-[0_16px_40px_rgba(15,23,42,0.06)] md:px-7">
+              방 상세 정보를 불러오는 중...
+            </article>
+          ) : null}
+
+          {isRoomDetailError ? (
+            <article className="rounded-[32px] border border-rose-200 bg-rose-50 px-6 py-10 text-center text-sm text-rose-600 shadow-[0_16px_40px_rgba(15,23,42,0.06)] md:px-7">
+              방 상세 정보를 불러오지 못했어요.
+              {roomDetailError instanceof Error ? ` ${roomDetailError.message}` : ''}
+            </article>
+          ) : null}
+
+          {roomDetail && !isRoomDetailLoading && !isRoomDetailError ? (
+            <article className="rounded-[32px] border border-slate-200/80 bg-white p-6 shadow-[0_16px_40px_rgba(15,23,42,0.06)] md:p-7">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span
+                      className={cn(
+                        'rounded-full px-3 py-1 text-xs font-semibold',
+                        detailRoomTypeStyleMap[toDetailRoomType(roomDetail.roomType)].badgeClassName,
+                      )}
+                    >
+                      {detailRoomTypeStyleMap[toDetailRoomType(roomDetail.roomType)].badgeLabel}
+                    </span>
+                    <span
+                      className={cn(
+                        'rounded-full px-3 py-1 text-xs font-semibold',
+                        detailRoomStatusStyleMap[toDetailRoomStatus(roomDetail.status)].badgeClassName,
+                      )}
+                    >
+                      {detailRoomStatusStyleMap[toDetailRoomStatus(roomDetail.status)].badgeLabel}
+                    </span>
+                  </div>
+                  <h3 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-slate-900">
+                    {roomDetail.title}
+                  </h3>
+                  <p className="mt-3 max-w-2xl whitespace-pre-line text-sm leading-7 text-slate-600">
+                    {roomDetail.description?.trim() || '방 소개가 아직 없어요.'}
+                  </p>
+                </div>
+
+                <div className="rounded-[24px] bg-slate-50 px-5 py-4">
+                  <div className="text-xs font-semibold text-slate-500">모집 정보</div>
+                  <div className="mt-2 flex items-center gap-2 text-sm text-slate-600">
+                    <Users className="h-4 w-4 text-slate-500" />
+                    <span className="font-semibold text-slate-900">
+                      {roomDetail.currentCount}/{roomDetail.maxMembersCount}명
+                    </span>
+                  </div>
+                  <div className="mt-2 rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-600">
+                    {roomDetail.minAge}-{roomDetail.maxAge}대
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                <section className="rounded-[24px] bg-slate-50 px-5 py-5">
+                  <h4 className="text-sm font-semibold text-slate-700">장소</h4>
+                  <div className="mt-3 inline-flex items-center gap-2 text-sm text-slate-600">
+                    <MapPin className="h-4 w-4 text-indigo-500" />
+                    {roomDetail.place}
+                  </div>
+                </section>
+
+                <section className="rounded-[24px] bg-slate-50 px-5 py-5">
+                  <h4 className="text-sm font-semibold text-slate-700">시간</h4>
+                  <div className="mt-3 inline-flex items-center gap-2 text-sm text-slate-600">
+                    <Clock3 className="h-4 w-4 text-indigo-500" />
+                    {formatLunchAt(roomDetail.lunchAt)}
+                  </div>
+                </section>
+              </div>
+            </article>
+          ) : null}
+        </>
       ) : null}
 
       {activeTab === 'LUNCH' ? <MainLunchMenuSection /> : null}

--- a/src/pages/main/ui/room/RoomCard.tsx
+++ b/src/pages/main/ui/room/RoomCard.tsx
@@ -5,6 +5,8 @@ import type { MainRoom } from './types';
 
 interface RoomCardProps {
   room: MainRoom;
+  isSelected: boolean;
+  onClick: () => void;
 }
 
 const roomTypeStyleMap = {
@@ -34,7 +36,7 @@ const roomTypeStyleMap = {
   },
 } as const;
 
-const RoomCard = ({ room }: RoomCardProps) => {
+const RoomCard = ({ room, isSelected, onClick }: RoomCardProps) => {
   const { badgeClassName, badgeLabel, buttonClassName, cardClassName, progressClassName } =
     roomTypeStyleMap[room.roomType];
   const progressPercent = (room.currentCount / room.capacity) * 100;
@@ -42,9 +44,11 @@ const RoomCard = ({ room }: RoomCardProps) => {
 
   return (
     <article
+      onClick={onClick}
       className={cn(
-        'overflow-hidden rounded-[28px] border shadow-[0_12px_30px_rgba(15,23,42,0.05)]',
+        'cursor-pointer overflow-hidden rounded-[28px] border shadow-[0_12px_30px_rgba(15,23,42,0.05)] transition',
         cardClassName,
+        isSelected ? 'ring-4 ring-slate-900/10' : 'hover:-translate-y-0.5',
       )}
     >
       <div className="p-5 md:p-6">

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -23,6 +23,21 @@ export interface RoomListFilters {
   maxAge?: number;
 }
 
+export interface RoomDetailResponse {
+  id: number;
+  hostUserId: number;
+  title: string;
+  roomType: 'MALE' | 'FEMALE' | 'ANY' | string;
+  maxMembersCount: number;
+  minAge: number;
+  maxAge: number;
+  place: string;
+  lunchAt: string;
+  status: 'OPEN' | 'FULL' | 'CLOSE' | string;
+  description: string | null;
+  currentCount: number;
+}
+
 export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsResponse> {
   const response = await client.get<GetRoomsResponse>('/api/v1/rooms', {
     params: {
@@ -32,6 +47,12 @@ export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsR
       maxAge: filters.maxAge,
     },
   });
+
+  return response.data;
+}
+
+export async function getRoomDetail(roomId: number): Promise<RoomDetailResponse> {
+  const response = await client.get<RoomDetailResponse>(`/api/v1/rooms/${roomId}`);
 
   return response.data;
 }

--- a/src/shared/api/rooms/roomsQueries.ts
+++ b/src/shared/api/rooms/roomsQueries.ts
@@ -1,8 +1,14 @@
 import { queryOptions } from '@tanstack/react-query';
-import { getRooms, type RoomListFilters } from '@/shared/api/rooms/rooms';
+import { getRoomDetail, getRooms, type RoomListFilters } from '@/shared/api/rooms/rooms';
 
 export const roomsListQueryOptions = (filters: RoomListFilters = {}) =>
   queryOptions({
     queryKey: ['rooms', 'list', filters],
     queryFn: () => getRooms(filters),
+  });
+
+export const roomDetailQueryOptions = (roomId: number) =>
+  queryOptions({
+    queryKey: ['rooms', 'detail', roomId],
+    queryFn: () => getRoomDetail(roomId),
   });


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 탭에 선택된 방 상세 패널을 추가하고, `GET /api/v1/rooms/{roomId}` 기반 상세 조회를 연결했습니다.
- 목록과 상세 query를 분리하고, 선택된 카드 기준으로 상세 패널이 갱신되도록 구성했습니다.
- 이번 PR은 조회와 선택 상태만 다루며, 참여/나가기/관리 액션은 후속 이슈로 분리합니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts`에 `RoomDetailResponse`, `getRoomDetail(roomId)` 추가
- `src/shared/api/rooms/roomsQueries.ts`에 `roomDetailQueryOptions(roomId)` 추가
- `src/pages/main/ui/room/RoomCard.tsx`에 `isSelected`, `onClick` props 추가 및 선택 강조 처리
- `src/pages/main/ui/layout/MainTabSection.tsx`에 `selectedRoomId` 상태, 상세 query, 상세 패널, 상세 loading/error 처리 추가
- 목록 변경 시 선택 상태를 자동 동기화하도록 처리
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- ROOM 카드 선택 시 하단 상세 패널이 갱신되고, 상세 loading/error 상태가 분리된 점이 핵심입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- `roomType: ANY`는 화면 표시에서 `MIXED`로 매핑합니다.
- `status`는 `OPEN/FULL/CLOSE`를 `모집중/정원도달/종료`로 매핑합니다.
- `lunchAt`은 기존 목록과 동일하게 `HH:mm`로 포맷합니다.
- `description`이 없으면 기본 안내 문구를 표시합니다.
- `hostUserId`는 내부 데이터로만 유지하고 화면에는 노출하지 않습니다.
- 참여/나가기 `#70`, `#71`, 멤버 조회/강퇴 `#72`, `#73`, 수정/삭제 `#74`, `#75`에서 이어서 처리합니다.

## 🧐 이슈 (Related Issues)

- Closes #68
