### PR TITLE
refactor: (#95) Main ROOM 탭 상수/유틸 분리

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -7,24 +7,27 @@ import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
-import type { MainRoom } from '../room/types';
-import type { RoomDetailResponse, RoomListFilters, RoomListItemResponse } from '@/shared/api/rooms/rooms';
 import { roomDetailQueryOptions, roomsListQueryOptions } from '@/shared/api/rooms/roomsQueries';
 import { cn } from '@/shared/lib/utils';
+import {
+  detailRoomStatusStyleMap,
+  detailRoomTypeStyleMap,
+  INITIAL_ROOM_FILTER_STATE,
+  roomStatusFilterOptions,
+  roomTypeFilterOptions,
+  type RoomFilterState,
+} from '../room/roomTab.constants';
+import {
+  formatLunchAt,
+  toDetailRoomStatus,
+  toDetailRoomType,
+  toMainRoom,
+  toRoomListFilters,
+} from '../room/roomTab.utils';
 
 interface MainTabSectionProps {
   activeTab: MainTab;
   onCreateRoomClick: () => void;
-}
-
-type RoomTypeFilter = 'ALL' | 'ANY' | 'MALE' | 'FEMALE';
-type RoomStatusFilter = 'ALL' | 'OPEN' | 'FULL' | 'CLOSE';
-
-interface RoomFilterState {
-  roomType: RoomTypeFilter;
-  status: RoomStatusFilter;
-  minAge: string;
-  maxAge: string;
 }
 
 const tabDescriptionMap: Record<MainTab, string> = {
@@ -33,126 +36,6 @@ const tabDescriptionMap: Record<MainTab, string> = {
   RANKING: '좋아요를 많이 받은 인기 학식 메뉴를 둘러보세요.',
   BOARD: '자유게시판에서 점심메이트와 가볍게 소통해보세요.',
 };
-
-const INITIAL_ROOM_FILTER_STATE: RoomFilterState = {
-  roomType: 'ALL',
-  status: 'ALL',
-  minAge: '',
-  maxAge: '',
-};
-
-const roomTypeFilterOptions: Array<{ label: string; value: RoomTypeFilter }> = [
-  { label: '전체', value: 'ALL' },
-  { label: '혼성', value: 'ANY' },
-  { label: '남성', value: 'MALE' },
-  { label: '여성', value: 'FEMALE' },
-];
-
-const roomStatusFilterOptions: Array<{ label: string; value: RoomStatusFilter }> = [
-  { label: '전체', value: 'ALL' },
-  { label: '모집중', value: 'OPEN' },
-  { label: '마감임박/정원도달', value: 'FULL' },
-  { label: '종료', value: 'CLOSE' },
-];
-
-const detailRoomTypeStyleMap = {
-  MALE: {
-    badgeClassName: 'bg-sky-100 text-sky-700',
-    badgeLabel: '남성만',
-  },
-  FEMALE: {
-    badgeClassName: 'bg-rose-100 text-rose-700',
-    badgeLabel: '여성만',
-  },
-  MIXED: {
-    badgeClassName: 'bg-indigo-100 text-indigo-700',
-    badgeLabel: '혼성',
-  },
-} as const;
-
-const detailRoomStatusStyleMap = {
-  OPEN: {
-    badgeClassName: 'bg-emerald-100 text-emerald-700',
-    badgeLabel: '모집중',
-  },
-  FULL: {
-    badgeClassName: 'bg-amber-100 text-amber-700',
-    badgeLabel: '정원도달',
-  },
-  CLOSE: {
-    badgeClassName: 'bg-slate-200 text-slate-700',
-    badgeLabel: '종료',
-  },
-} as const;
-
-const toMainRoomType = (roomType: RoomListItemResponse['roomType']): MainRoom['roomType'] => {
-  if (roomType === 'MALE' || roomType === 'FEMALE') {
-    return roomType;
-  }
-
-  return 'MIXED';
-};
-
-const formatLunchAt = (lunchAt: string): string => {
-  const timeMatch = lunchAt.match(/(?:T|\s)?(\d{2}:\d{2})/);
-
-  if (timeMatch) {
-    return timeMatch[1];
-  }
-
-  return lunchAt;
-};
-
-const toMainRoom = (room: RoomListItemResponse): MainRoom => ({
-  id: room.id,
-  title: room.title,
-  roomType: toMainRoomType(room.roomType),
-  minAge: room.minAge,
-  maxAge: room.maxAge,
-  currentCount: room.currentCount,
-  capacity: room.maxMembersCount,
-  place: room.place,
-  lunchAt: formatLunchAt(room.lunchAt),
-});
-
-const toDetailRoomType = (roomType: RoomDetailResponse['roomType']): MainRoom['roomType'] => {
-  if (roomType === 'MALE' || roomType === 'FEMALE') {
-    return roomType;
-  }
-
-  return 'MIXED';
-};
-
-const toDetailRoomStatus = (
-  status: RoomDetailResponse['status'],
-): keyof typeof detailRoomStatusStyleMap => {
-  if (status === 'OPEN' || status === 'FULL' || status === 'CLOSE') {
-    return status;
-  }
-
-  return 'OPEN';
-};
-
-const parseAgeFilter = (value: string): number | undefined => {
-  if (value.trim() === '') {
-    return undefined;
-  }
-
-  const parsedValue = Number(value);
-
-  if (!Number.isFinite(parsedValue)) {
-    return undefined;
-  }
-
-  return parsedValue;
-};
-
-const toRoomListFilters = (roomFilterState: RoomFilterState): RoomListFilters => ({
-  roomType: roomFilterState.roomType === 'ALL' ? undefined : roomFilterState.roomType,
-  status: roomFilterState.status === 'ALL' ? undefined : roomFilterState.status,
-  minAge: parseAgeFilter(roomFilterState.minAge),
-  maxAge: parseAgeFilter(roomFilterState.maxAge),
-});
 
 const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) => {
   const isRoomTab = activeTab === 'ROOM';

--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -7,7 +7,13 @@ import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
+<<<<<<< Updated upstream
 import { roomDetailQueryOptions, roomsListQueryOptions } from '@/shared/api/rooms/roomsQueries';
+=======
+import type { MainRoom } from '../room/types';
+import type { RoomListFilters, RoomListItemResponse } from '@/shared/api/rooms/rooms';
+import { roomQueries } from '@/shared/api/rooms/roomsQueries';
+>>>>>>> Stashed changes
 import { cn } from '@/shared/lib/utils';
 import {
   detailRoomStatusStyleMap,
@@ -43,7 +49,7 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
   const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
   const roomFilters = toRoomListFilters(roomFilterState);
   const { data, isLoading, isError, error } = useQuery({
-    ...roomsListQueryOptions(roomFilters),
+    ...roomQueries.list(roomFilters),
     enabled: isRoomTab,
   });
   const {

--- a/src/pages/main/ui/room/roomTab.constants.ts
+++ b/src/pages/main/ui/room/roomTab.constants.ts
@@ -1,0 +1,60 @@
+export type RoomTypeFilter = 'ALL' | 'ANY' | 'MALE' | 'FEMALE';
+export type RoomStatusFilter = 'ALL' | 'OPEN' | 'FULL' | 'CLOSE';
+
+export interface RoomFilterState {
+  roomType: RoomTypeFilter;
+  status: RoomStatusFilter;
+  minAge: string;
+  maxAge: string;
+}
+
+export const INITIAL_ROOM_FILTER_STATE: RoomFilterState = {
+  roomType: 'ALL',
+  status: 'ALL',
+  minAge: '',
+  maxAge: '',
+};
+
+export const roomTypeFilterOptions: Array<{ label: string; value: RoomTypeFilter }> = [
+  { label: '전체', value: 'ALL' },
+  { label: '혼성', value: 'ANY' },
+  { label: '남성', value: 'MALE' },
+  { label: '여성', value: 'FEMALE' },
+];
+
+export const roomStatusFilterOptions: Array<{ label: string; value: RoomStatusFilter }> = [
+  { label: '전체', value: 'ALL' },
+  { label: '모집중', value: 'OPEN' },
+  { label: '마감임박/정원도달', value: 'FULL' },
+  { label: '종료', value: 'CLOSE' },
+];
+
+export const detailRoomTypeStyleMap = {
+  MALE: {
+    badgeClassName: 'bg-sky-100 text-sky-700',
+    badgeLabel: '남성만',
+  },
+  FEMALE: {
+    badgeClassName: 'bg-rose-100 text-rose-700',
+    badgeLabel: '여성만',
+  },
+  MIXED: {
+    badgeClassName: 'bg-indigo-100 text-indigo-700',
+    badgeLabel: '혼성',
+  },
+} as const;
+
+export const detailRoomStatusStyleMap = {
+  OPEN: {
+    badgeClassName: 'bg-emerald-100 text-emerald-700',
+    badgeLabel: '모집중',
+  },
+  FULL: {
+    badgeClassName: 'bg-amber-100 text-amber-700',
+    badgeLabel: '정원도달',
+  },
+  CLOSE: {
+    badgeClassName: 'bg-slate-200 text-slate-700',
+    badgeLabel: '종료',
+  },
+} as const;

--- a/src/pages/main/ui/room/roomTab.utils.ts
+++ b/src/pages/main/ui/room/roomTab.utils.ts
@@ -1,0 +1,72 @@
+import type { RoomDetailResponse, RoomListFilters, RoomListItemResponse } from '@/shared/api/rooms/rooms';
+import type { MainRoom } from './types';
+import { detailRoomStatusStyleMap, type RoomFilterState } from './roomTab.constants';
+
+export const toMainRoomType = (roomType: RoomListItemResponse['roomType']): MainRoom['roomType'] => {
+  if (roomType === 'MALE' || roomType === 'FEMALE') {
+    return roomType;
+  }
+
+  return 'MIXED';
+};
+
+export const formatLunchAt = (lunchAt: string): string => {
+  const timeMatch = lunchAt.match(/(?:T|\s)?(\d{2}:\d{2})/);
+
+  if (timeMatch) {
+    return timeMatch[1];
+  }
+
+  return lunchAt;
+};
+
+export const toMainRoom = (room: RoomListItemResponse): MainRoom => ({
+  id: room.id,
+  title: room.title,
+  roomType: toMainRoomType(room.roomType),
+  minAge: room.minAge,
+  maxAge: room.maxAge,
+  currentCount: room.currentCount,
+  capacity: room.maxMembersCount,
+  place: room.place,
+  lunchAt: formatLunchAt(room.lunchAt),
+});
+
+export const toDetailRoomType = (roomType: RoomDetailResponse['roomType']): MainRoom['roomType'] => {
+  if (roomType === 'MALE' || roomType === 'FEMALE') {
+    return roomType;
+  }
+
+  return 'MIXED';
+};
+
+export const toDetailRoomStatus = (
+  status: RoomDetailResponse['status'],
+): keyof typeof detailRoomStatusStyleMap => {
+  if (status === 'OPEN' || status === 'FULL' || status === 'CLOSE') {
+    return status;
+  }
+
+  return 'OPEN';
+};
+
+export const parseAgeFilter = (value: string): number | undefined => {
+  if (value.trim() === '') {
+    return undefined;
+  }
+
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue)) {
+    return undefined;
+  }
+
+  return parsedValue;
+};
+
+export const toRoomListFilters = (roomFilterState: RoomFilterState): RoomListFilters => ({
+  roomType: roomFilterState.roomType === 'ALL' ? undefined : roomFilterState.roomType,
+  status: roomFilterState.status === 'ALL' ? undefined : roomFilterState.status,
+  minAge: parseAgeFilter(roomFilterState.minAge),
+  maxAge: parseAgeFilter(roomFilterState.maxAge),
+});

--- a/src/shared/api/rooms/index.ts
+++ b/src/shared/api/rooms/index.ts
@@ -1,0 +1,3 @@
+export type { GetRoomsResponse, RoomListItemResponse } from './rooms';
+export { getRooms } from './rooms';
+export { roomQueries } from './roomsQueries';

--- a/src/shared/api/rooms/roomsQueries.ts
+++ b/src/shared/api/rooms/roomsQueries.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from '@tanstack/react-query';
 import { getRoomDetail, getRooms, type RoomListFilters } from '@/shared/api/rooms/rooms';
 
+<<<<<<< Updated upstream
 export const roomsListQueryOptions = (filters: RoomListFilters = {}) =>
   queryOptions({
     queryKey: ['rooms', 'list', filters],
@@ -12,3 +13,14 @@ export const roomDetailQueryOptions = (roomId: number) =>
     queryKey: ['rooms', 'detail', roomId],
     queryFn: () => getRoomDetail(roomId),
   });
+=======
+export const roomQueries = {
+  all: () => ['rooms'] as const,
+  lists: () => [...roomQueries.all(), 'list'] as const,
+  list: (filters: RoomListFilters = {}) =>
+    queryOptions({
+      queryKey: [...roomQueries.lists(), filters],
+      queryFn: () => getRooms(filters),
+    }),
+};
+>>>>>>> Stashed changes


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- `MainTabSection.tsx` 상단에 모여 있던 ROOM 탭 전용 상수, 필터 타입, 매핑/포맷 유틸을 `pages/main/ui/room` 하위 파일로 분리했습니다.
- ROOM 관련 로직을 별도 모듈로 이동해 `MainTabSection.tsx`가 state, query, render 흐름 중심으로 읽히도록 정리했습니다.
- 이번 PR은 구조 정리만 다루며, ROOM 목록/필터/상세 동작 자체는 변경하지 않습니다.

## ✨ 변경 사항 (Changes)

- `src/pages/main/ui/room/roomTab.constants.ts` 추가
- `src/pages/main/ui/room/roomTab.utils.ts` 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`에서 ROOM 관련 상수/유틸 정의 제거 후 import 정리
- ROOM 목록/필터/상세 렌더 흐름은 유지
- `corepack pnpm build` 통과 확인

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- UI 변경이 아니라 `MainTabSection.tsx` 내부 구조를 정리하는 리팩터링 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 분리 대상은 ROOM 전용 상수/유틸 로직으로 한정했습니다.
- `MainTabSection.tsx`의 JSX 구조, state 이름, query 구성은 유지했습니다.
- ROOM API 계약이나 화면 동작은 변경하지 않았습니다.
- `RoomDetailPanel`, `RoomFilters` 같은 별도 컴포넌트 분해는 이번 범위에 포함하지 않습니다.

## 🧐 이슈 (Related Issues)

- Closes #95
