### PR TITLE
feat: (#69) 방 생성 연결

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -7,13 +7,7 @@ import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
-<<<<<<< Updated upstream
-import { roomDetailQueryOptions, roomsListQueryOptions } from '@/shared/api/rooms/roomsQueries';
-=======
-import type { MainRoom } from '../room/types';
-import type { RoomListFilters, RoomListItemResponse } from '@/shared/api/rooms/rooms';
 import { roomQueries } from '@/shared/api/rooms/roomsQueries';
->>>>>>> Stashed changes
 import { cn } from '@/shared/lib/utils';
 import {
   detailRoomStatusStyleMap,
@@ -25,6 +19,7 @@ import {
 } from '../room/roomTab.constants';
 import {
   formatLunchAt,
+  getDetailRoomCurrentCount,
   toDetailRoomStatus,
   toDetailRoomType,
   toMainRoom,
@@ -58,7 +53,7 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
     isError: isRoomDetailError,
     error: roomDetailError,
   } = useQuery({
-    ...roomDetailQueryOptions(selectedRoomId ?? 0),
+    ...roomQueries.detail(selectedRoomId ?? 0),
     enabled: isRoomTab && selectedRoomId !== null,
   });
   const rooms = data?.items.map(toMainRoom) ?? [];
@@ -73,7 +68,8 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
       return;
     }
 
-    const hasSelectedRoom = selectedRoomId !== null && rooms.some((room) => room.id === selectedRoomId);
+    const hasSelectedRoom =
+      selectedRoomId !== null && rooms.some((room) => room.id === selectedRoomId);
 
     if (!hasSelectedRoom) {
       setSelectedRoomId(rooms[0].id);
@@ -85,7 +81,13 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
       <div className="flex flex-col gap-4 rounded-[28px] border border-slate-200/80 bg-white px-5 py-5 shadow-[0_12px_30px_rgba(15,23,42,0.05)] md:flex-row md:items-center md:justify-between md:px-6">
         <div>
           <h2 className="text-[22px] font-bold tracking-[-0.03em] text-slate-900">
-            {isRoomTab ? '점심 방 둘러보기' : activeTab === 'LUNCH' ? '오늘의 학식 메뉴' : activeTab === 'RANKING' ? '지금 인기 있는 메뉴' : '자유게시판'}
+            {isRoomTab
+              ? '점심 방 둘러보기'
+              : activeTab === 'LUNCH'
+                ? '오늘의 학식 메뉴'
+                : activeTab === 'RANKING'
+                  ? '지금 인기 있는 메뉴'
+                  : '자유게시판'}
           </h2>
           <p className="mt-2 text-sm leading-6 text-slate-500">{tabDescriptionMap[activeTab]}</p>
         </div>
@@ -263,7 +265,8 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
                     <span
                       className={cn(
                         'rounded-full px-3 py-1 text-xs font-semibold',
-                        detailRoomStatusStyleMap[toDetailRoomStatus(roomDetail.status)].badgeClassName,
+                        detailRoomStatusStyleMap[toDetailRoomStatus(roomDetail.status)]
+                          .badgeClassName,
                       )}
                     >
                       {detailRoomStatusStyleMap[toDetailRoomStatus(roomDetail.status)].badgeLabel}
@@ -282,7 +285,7 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
                   <div className="mt-2 flex items-center gap-2 text-sm text-slate-600">
                     <Users className="h-4 w-4 text-slate-500" />
                     <span className="font-semibold text-slate-900">
-                      {roomDetail.currentCount}/{roomDetail.maxMembersCount}명
+                      {getDetailRoomCurrentCount(roomDetail)}/{roomDetail.maxMembersCount}명
                     </span>
                   </div>
                   <div className="mt-2 rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-600">

--- a/src/pages/main/ui/room/CreateRoomModal.tsx
+++ b/src/pages/main/ui/room/CreateRoomModal.tsx
@@ -1,6 +1,10 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import { useForm } from '@tanstack/react-form';
 import { X } from 'lucide-react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
+import { createRoom } from '@/shared/api/rooms/rooms';
+import { roomQueries } from '@/shared/api/rooms/roomsQueries';
 
 interface CreateRoomModalProps {
   isOpen: boolean;
@@ -18,6 +22,10 @@ interface CreateRoomFormState {
   maxAge: string;
 }
 
+interface ApiErrorPayload {
+  message?: string | string[];
+}
+
 const INITIAL_CREATE_ROOM_FORM_STATE: CreateRoomFormState = {
   title: '',
   description: '',
@@ -29,12 +37,156 @@ const INITIAL_CREATE_ROOM_FORM_STATE: CreateRoomFormState = {
   maxAge: '24',
 };
 
+const parseRequiredNumber = (value: string) => {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue === '') {
+    return null;
+  }
+
+  const parsedValue = Number(trimmedValue);
+
+  if (!Number.isFinite(parsedValue)) {
+    return null;
+  }
+
+  return parsedValue;
+};
+
+const toFutureLunchAt = (timeValue: string) => {
+  const trimmedValue = timeValue.trim();
+
+  if (!/^\d{2}:\d{2}$/.test(trimmedValue)) {
+    return null;
+  }
+
+  const [hours, minutes] = trimmedValue.split(':').map(Number);
+
+  if (
+    !Number.isInteger(hours) ||
+    !Number.isInteger(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+
+  const now = new Date();
+  const lunchAt = new Date(now);
+
+  lunchAt.setHours(hours, minutes, 0, 0);
+
+  if (lunchAt.getTime() <= now.getTime()) {
+    lunchAt.setDate(lunchAt.getDate() + 1);
+  }
+
+  return lunchAt.toISOString();
+};
+
+const getCreateRoomErrorMessage = (error: unknown) => {
+  if (isAxiosError<ApiErrorPayload>(error)) {
+    const responseMessage = error.response?.data?.message;
+
+    if (Array.isArray(responseMessage) && responseMessage.length > 0) {
+      return responseMessage.join(' ');
+    }
+
+    if (typeof responseMessage === 'string' && responseMessage.trim() !== '') {
+      return responseMessage;
+    }
+  }
+
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+
+  return '방 만들기에 실패했어요. 잠시 후 다시 시도해 주세요.';
+};
+
 const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const queryClient = useQueryClient();
+  const [submitMessage, setSubmitMessage] = useState('');
+  const [submitMessageTone, setSubmitMessageTone] = useState<'error' | 'success'>('success');
+
+  const createRoomMutation = useMutation({
+    mutationFn: createRoom,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: roomQueries.lists() }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.details() }),
+      ]);
+
+      handleClose();
+    },
+    onError: (error) => {
+      setSubmitMessage(getCreateRoomErrorMessage(error));
+      setSubmitMessageTone('error');
+    },
+  });
 
   const createRoomForm = useForm({
     defaultValues: INITIAL_CREATE_ROOM_FORM_STATE,
-    onSubmit: async () => undefined,
+    onSubmit: async ({ value }) => {
+      const title = value.title.trim();
+      const place = value.place.trim();
+      const description = value.description.trim();
+      const maxMembersCount = parseRequiredNumber(value.capacity);
+      const minAge = parseRequiredNumber(value.minAge);
+      const maxAge = parseRequiredNumber(value.maxAge);
+      const lunchAt = toFutureLunchAt(value.lunchAt);
+
+      if (!title) {
+        setSubmitMessage('방 제목을 입력해 주세요.');
+        setSubmitMessageTone('error');
+        return;
+      }
+
+      if (!place) {
+        setSubmitMessage('모임 장소를 입력해 주세요.');
+        setSubmitMessageTone('error');
+        return;
+      }
+
+      if (maxMembersCount === null || maxMembersCount <= 0) {
+        setSubmitMessage('모집 인원은 1명 이상 숫자로 입력해 주세요.');
+        setSubmitMessageTone('error');
+        return;
+      }
+
+      if (minAge === null || minAge < 0 || maxAge === null || maxAge < 0) {
+        setSubmitMessage('나이는 0 이상 숫자로 입력해 주세요.');
+        setSubmitMessageTone('error');
+        return;
+      }
+
+      if (minAge > maxAge) {
+        setSubmitMessage('최소 나이는 최대 나이보다 클 수 없어요.');
+        setSubmitMessageTone('error');
+        return;
+      }
+
+      if (!lunchAt) {
+        setSubmitMessage('모임 시간을 올바르게 입력해 주세요.');
+        setSubmitMessageTone('error');
+        return;
+      }
+
+      setSubmitMessage('');
+
+      await createRoomMutation.mutateAsync({
+        title,
+        description: description || undefined,
+        roomType: value.roomType === 'MIXED' ? 'ANY' : value.roomType,
+        maxMembersCount,
+        place,
+        lunchAt,
+        minAge,
+        maxAge,
+      });
+    },
   });
 
   useEffect(() => {
@@ -56,10 +208,13 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
 
   const handleClose = () => {
     createRoomForm.reset();
+    createRoomMutation.reset();
+    setSubmitMessage('');
+    setSubmitMessageTone('success');
     onClose();
   };
 
-  const handleDialogClick = (event: React.MouseEvent<HTMLDialogElement>) => {
+  const handleDialogClick = (event: MouseEvent<HTMLDialogElement>) => {
     if (event.target === dialogRef.current) {
       handleClose();
     }
@@ -105,7 +260,10 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
                   <span className="text-sm font-semibold text-slate-700">방 제목</span>
                   <input
                     value={field.state.value}
-                    onChange={(event) => field.handleChange(event.target.value)}
+                    onChange={(event) => {
+                      field.handleChange(event.target.value);
+                      setSubmitMessage('');
+                    }}
                     placeholder="예: 점심 같이 먹어요"
                     className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
                   />
@@ -120,7 +278,10 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
                   <span className="text-sm font-semibold text-slate-700">방 소개</span>
                   <textarea
                     value={field.state.value}
-                    onChange={(event) => field.handleChange(event.target.value)}
+                    onChange={(event) => {
+                      field.handleChange(event.target.value);
+                      setSubmitMessage('');
+                    }}
                     placeholder="모집하고 싶은 분위기나 식당 정보를 적어주세요"
                     className="min-h-[120px] rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
                   />
@@ -135,9 +296,10 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
                   <span className="text-sm font-semibold text-slate-700">방 구분</span>
                   <select
                     value={field.state.value}
-                    onChange={(event) =>
-                      field.handleChange(event.target.value as CreateRoomFormState['roomType'])
-                    }
+                    onChange={(event) => {
+                      field.handleChange(event.target.value as CreateRoomFormState['roomType']);
+                      setSubmitMessage('');
+                    }}
                     className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
                   >
                     <option value="MIXED">혼성</option>
@@ -154,8 +316,13 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
                 <label className="flex flex-col gap-2">
                   <span className="text-sm font-semibold text-slate-700">모집 인원</span>
                   <input
+                    type="number"
+                    min="1"
                     value={field.state.value}
-                    onChange={(event) => field.handleChange(event.target.value)}
+                    onChange={(event) => {
+                      field.handleChange(event.target.value);
+                      setSubmitMessage('');
+                    }}
                     className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
                   />
                 </label>
@@ -168,8 +335,13 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
                 <label className="flex flex-col gap-2">
                   <span className="text-sm font-semibold text-slate-700">최소 나이</span>
                   <input
+                    type="number"
+                    min="0"
                     value={field.state.value}
-                    onChange={(event) => field.handleChange(event.target.value)}
+                    onChange={(event) => {
+                      field.handleChange(event.target.value);
+                      setSubmitMessage('');
+                    }}
                     className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
                   />
                 </label>
@@ -182,8 +354,13 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
                 <label className="flex flex-col gap-2">
                   <span className="text-sm font-semibold text-slate-700">최대 나이</span>
                   <input
+                    type="number"
+                    min="0"
                     value={field.state.value}
-                    onChange={(event) => field.handleChange(event.target.value)}
+                    onChange={(event) => {
+                      field.handleChange(event.target.value);
+                      setSubmitMessage('');
+                    }}
                     className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
                   />
                 </label>
@@ -197,7 +374,10 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
                   <span className="text-sm font-semibold text-slate-700">모임 장소</span>
                   <input
                     value={field.state.value}
-                    onChange={(event) => field.handleChange(event.target.value)}
+                    onChange={(event) => {
+                      field.handleChange(event.target.value);
+                      setSubmitMessage('');
+                    }}
                     placeholder="예: 학생식당"
                     className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
                   />
@@ -211,14 +391,28 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
                 <label className="flex flex-col gap-2">
                   <span className="text-sm font-semibold text-slate-700">모임 시간</span>
                   <input
+                    type="time"
                     value={field.state.value}
-                    onChange={(event) => field.handleChange(event.target.value)}
+                    onChange={(event) => {
+                      field.handleChange(event.target.value);
+                      setSubmitMessage('');
+                    }}
                     className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
                   />
                 </label>
               )}
             />
           </div>
+
+          {submitMessage ? (
+            <p
+              className={`mt-4 text-sm ${
+                submitMessageTone === 'error' ? 'text-rose-500' : 'text-emerald-600'
+              }`}
+            >
+              {submitMessage}
+            </p>
+          ) : null}
 
           <div className="mt-6 flex flex-col-reverse gap-3 md:flex-row md:justify-end">
             <button
@@ -230,9 +424,10 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
             </button>
             <button
               type="submit"
-              className="rounded-2xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(99,102,241,0.28)] transition hover:bg-indigo-600"
+              disabled={createRoomMutation.isPending}
+              className="rounded-2xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(99,102,241,0.28)] transition hover:bg-indigo-600 disabled:cursor-not-allowed disabled:bg-indigo-300"
             >
-              방 만들기
+              {createRoomMutation.isPending ? '방 만드는 중...' : '방 만들기'}
             </button>
           </div>
         </form>

--- a/src/pages/main/ui/room/roomTab.utils.ts
+++ b/src/pages/main/ui/room/roomTab.utils.ts
@@ -50,6 +50,8 @@ export const toDetailRoomStatus = (
   return 'OPEN';
 };
 
+export const getDetailRoomCurrentCount = (room: RoomDetailResponse) => room.currentMembersCount;
+
 export const parseAgeFilter = (value: string): number | undefined => {
   if (value.trim() === '') {
     return undefined;

--- a/src/shared/api/rooms/index.ts
+++ b/src/shared/api/rooms/index.ts
@@ -1,3 +1,8 @@
-export type { GetRoomsResponse, RoomListItemResponse } from './rooms';
-export { getRooms } from './rooms';
+export type {
+  CreateRoomRequest,
+  GetRoomsResponse,
+  RoomDetailResponse,
+  RoomListItemResponse,
+} from './rooms';
+export { createRoom, getRoomDetail, getRooms } from './rooms';
 export { roomQueries } from './roomsQueries';

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -35,7 +35,18 @@ export interface RoomDetailResponse {
   lunchAt: string;
   status: 'OPEN' | 'FULL' | 'CLOSE' | string;
   description: string | null;
-  currentCount: number;
+  currentMembersCount: number;
+}
+
+export interface CreateRoomRequest {
+  title: string;
+  description?: string;
+  roomType: 'MALE' | 'FEMALE' | 'ANY';
+  maxMembersCount: number;
+  place: string;
+  lunchAt: string;
+  minAge: number;
+  maxAge: number;
 }
 
 export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsResponse> {
@@ -53,6 +64,12 @@ export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsR
 
 export async function getRoomDetail(roomId: number): Promise<RoomDetailResponse> {
   const response = await client.get<RoomDetailResponse>(`/api/v1/rooms/${roomId}`);
+
+  return response.data;
+}
+
+export async function createRoom(payload: CreateRoomRequest): Promise<RoomDetailResponse> {
+  const response = await client.post<RoomDetailResponse>('/api/v1/rooms', payload);
 
   return response.data;
 }

--- a/src/shared/api/rooms/roomsQueries.ts
+++ b/src/shared/api/rooms/roomsQueries.ts
@@ -1,19 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 import { getRoomDetail, getRooms, type RoomListFilters } from '@/shared/api/rooms/rooms';
 
-<<<<<<< Updated upstream
-export const roomsListQueryOptions = (filters: RoomListFilters = {}) =>
-  queryOptions({
-    queryKey: ['rooms', 'list', filters],
-    queryFn: () => getRooms(filters),
-  });
-
-export const roomDetailQueryOptions = (roomId: number) =>
-  queryOptions({
-    queryKey: ['rooms', 'detail', roomId],
-    queryFn: () => getRoomDetail(roomId),
-  });
-=======
 export const roomQueries = {
   all: () => ['rooms'] as const,
   lists: () => [...roomQueries.all(), 'list'] as const,
@@ -22,5 +9,10 @@ export const roomQueries = {
       queryKey: [...roomQueries.lists(), filters],
       queryFn: () => getRooms(filters),
     }),
+  details: () => [...roomQueries.all(), 'detail'] as const,
+  detail: (roomId: number) =>
+    queryOptions({
+      queryKey: [...roomQueries.details(), roomId],
+      queryFn: () => getRoomDetail(roomId),
+    }),
 };
->>>>>>> Stashed changes


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- `CreateRoomModal` submit을 실제 `POST /api/v1/rooms`와 연결했습니다.
- ROOM 생성 요청에 맞게 입력값을 정제하고, 성공 시 room 목록/상세 query를 재조회하도록 구성했습니다.
- 작업 과정에서 room 베이스에 남아 있던 query/detail 충돌 마커도 함께 정리해, 현재 ROOM 탭 흐름이 정상적으로 이어지도록 맞췄습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts`에 `CreateRoomRequest`, `createRoom(payload)` 추가
- `src/shared/api/rooms/index.ts` export 정리
- `src/shared/api/rooms/roomsQueries.ts`에서 room list/detail query-factory 구조 정리
- `src/pages/main/ui/room/CreateRoomModal.tsx`에 생성 mutation, 입력값 정제, validation, 성공/실패 메시지 처리 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`에서 room detail query 사용부를 `roomQueries.detail(...)` 기준으로 정리
- `src/pages/main/ui/room/roomTab.utils.ts`에 상세 응답 `currentMembersCount` 대응 유틸 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 ROOM 생성 연결과 room 베이스 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- `roomType`은 UI의 `MIXED`를 API 요청에서는 `ANY`로 매핑합니다.
- `capacity`, `minAge`, `maxAge`는 문자열 입력을 숫자로 정제한 뒤 전송합니다.
- `lunchAt`은 `HH:mm` 입력을 기준으로, 현재 시각 이후가 되도록 오늘 또는 다음 날 ISO datetime으로 변환해 전송합니다.
- 생성 성공 후에는 새 방을 자동 선택하지 않고, room list/detail query invalidate로 최신 상태만 반영합니다.
- 현재 로컬 환경에는 `node_modules`가 없어 `pnpm build`, `pnpm lint`는 아직 실행하지 못했습니다.

## 🧐 이슈 (Related Issues)

- Closes #69
