### PR TITLE
feat: (#70) 방 참여 연결

### DIFF
--- a/src/pages/main/ui/layout/MainPage.tsx
+++ b/src/pages/main/ui/layout/MainPage.tsx
@@ -22,6 +22,7 @@ const MainPage = () => {
         <MainTabSection
           activeTab={activeTab}
           onCreateRoomClick={() => setIsCreateRoomModalOpen(true)}
+          onJoinRequireLogin={() => setIsLoginModalOpen(true)}
         />
       </main>
 

--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import { Clock3, MapPin, Plus, Users } from 'lucide-react';
+import { isAuthenticated } from '@/app/authSessionStore';
 import type { MainTab } from '../../model/types';
 import MainBoardSection from '../board/MainBoardSection';
 import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
+import { joinRoom } from '@/shared/api/rooms/rooms';
 import { roomQueries } from '@/shared/api/rooms/roomsQueries';
 import { cn } from '@/shared/lib/utils';
 import {
@@ -29,6 +32,11 @@ import {
 interface MainTabSectionProps {
   activeTab: MainTab;
   onCreateRoomClick: () => void;
+  onJoinRequireLogin: () => void;
+}
+
+interface ApiErrorPayload {
+  message?: string | string[];
 }
 
 const tabDescriptionMap: Record<MainTab, string> = {
@@ -38,10 +46,52 @@ const tabDescriptionMap: Record<MainTab, string> = {
   BOARD: '자유게시판에서 점심메이트와 가볍게 소통해보세요.',
 };
 
-const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) => {
+const getJoinErrorMessage = (error: unknown) => {
+  if (isAxiosError<ApiErrorPayload>(error)) {
+    const responseMessage = error.response?.data?.message;
+
+    if (Array.isArray(responseMessage) && responseMessage.length > 0) {
+      return responseMessage.join(' ');
+    }
+
+    if (typeof responseMessage === 'string' && responseMessage.trim() !== '') {
+      return responseMessage;
+    }
+
+    if (error.response?.status === 403) {
+      return '참여할 수 없는 방이에요.';
+    }
+
+    if (error.response?.status === 404) {
+      return '방을 찾을 수 없어요.';
+    }
+
+    if (error.response?.status === 409) {
+      return '이미 다른 방에 참여 중이거나 이미 참여한 방이에요.';
+    }
+  }
+
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+
+  return '방 참여에 실패했어요. 잠시 후 다시 시도해 주세요.';
+};
+
+const MainTabSection = ({
+  activeTab,
+  onCreateRoomClick,
+  onJoinRequireLogin,
+}: MainTabSectionProps) => {
+  const queryClient = useQueryClient();
   const isRoomTab = activeTab === 'ROOM';
   const [roomFilterState, setRoomFilterState] = useState<RoomFilterState>(INITIAL_ROOM_FILTER_STATE);
   const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
+  const [joinedRoomId, setJoinedRoomId] = useState<number | null>(null);
+  const [roomActionMessage, setRoomActionMessage] = useState('');
+  const [roomActionMessageTone, setRoomActionMessageTone] = useState<'success' | 'error'>(
+    'success',
+  );
   const roomFilters = toRoomListFilters(roomFilterState);
   const { data, isLoading, isError, error } = useQuery({
     ...roomQueries.list(roomFilters),
@@ -55,6 +105,30 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
   } = useQuery({
     ...roomQueries.detail(selectedRoomId ?? 0),
     enabled: isRoomTab && selectedRoomId !== null,
+  });
+  const joinRoomMutation = useMutation({
+    mutationFn: joinRoom,
+    onSuccess: async ({ roomId }) => {
+      setJoinedRoomId(roomId);
+      setRoomActionMessage('방에 참여했어요.');
+      setRoomActionMessageTone('success');
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: roomQueries.lists() }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.detail(roomId).queryKey }),
+      ]);
+    },
+    onError: (error) => {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        setRoomActionMessage('로그인 후 방에 참여할 수 있어요.');
+        setRoomActionMessageTone('error');
+        onJoinRequireLogin();
+        return;
+      }
+
+      setRoomActionMessage(getJoinErrorMessage(error));
+      setRoomActionMessageTone('error');
+    },
   });
   const rooms = data?.items.map(toMainRoom) ?? [];
 
@@ -75,6 +149,20 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
       setSelectedRoomId(rooms[0].id);
     }
   }, [isRoomTab, rooms, selectedRoomId]);
+
+  const handleJoinClick = (roomId: number) => {
+    if (!isAuthenticated()) {
+      setRoomActionMessage('로그인 후 방에 참여할 수 있어요.');
+      setRoomActionMessageTone('error');
+      onJoinRequireLogin();
+      return;
+    }
+
+    setRoomActionMessage('');
+    joinRoomMutation.mutate(roomId);
+  };
+
+  const hasJoinedActiveRoom = joinedRoomId !== null;
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -200,6 +288,19 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
 
       {isRoomTab && !isLoading && !isError ? <RoomSummary roomCount={rooms.length} /> : null}
 
+      {isRoomTab && roomActionMessage ? (
+        <section
+          className={cn(
+            'rounded-[24px] border px-5 py-4 text-sm shadow-[0_12px_30px_rgba(15,23,42,0.05)]',
+            roomActionMessageTone === 'error'
+              ? 'border-rose-200 bg-rose-50 text-rose-600'
+              : 'border-emerald-200 bg-emerald-50 text-emerald-700',
+          )}
+        >
+          {roomActionMessage}
+        </section>
+      ) : null}
+
       {activeTab === 'ROOM' ? (
         <div className="space-y-4 md:space-y-5">
           {isLoading ? (
@@ -222,14 +323,34 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
           ) : null}
 
           {!isLoading && !isError
-            ? rooms.map((room) => (
-                <RoomCard
-                  key={room.id}
-                  room={room}
-                  isSelected={selectedRoomId === room.id}
-                  onClick={() => setSelectedRoomId(room.id)}
-                />
-              ))
+            ? rooms.map((room) => {
+                const isJoinPending =
+                  joinRoomMutation.isPending && joinRoomMutation.variables === room.id;
+                const isFullRoom = room.currentCount >= room.capacity;
+                const isJoinedRoom = joinedRoomId === room.id;
+                const joinDisabled =
+                  isFullRoom || isJoinPending || (hasJoinedActiveRoom && !isJoinedRoom);
+                const joinLabel = isFullRoom
+                  ? '정원 마감'
+                  : isJoinedRoom
+                    ? '참여 완료'
+                    : hasJoinedActiveRoom
+                      ? '다른 방 참여 중'
+                      : '참여하기';
+
+                return (
+                  <RoomCard
+                    key={room.id}
+                    room={room}
+                    isSelected={selectedRoomId === room.id}
+                    onClick={() => setSelectedRoomId(room.id)}
+                    onJoinClick={handleJoinClick}
+                    isJoinPending={isJoinPending}
+                    joinDisabled={joinDisabled}
+                    joinLabel={joinLabel}
+                  />
+                );
+              })
             : null}
         </div>
       ) : null}

--- a/src/pages/main/ui/room/RoomCard.tsx
+++ b/src/pages/main/ui/room/RoomCard.tsx
@@ -1,3 +1,4 @@
+import { type MouseEvent } from 'react';
 import { Clock3, MapPin, Users } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
@@ -7,6 +8,10 @@ interface RoomCardProps {
   room: MainRoom;
   isSelected: boolean;
   onClick: () => void;
+  onJoinClick: (roomId: number) => void;
+  isJoinPending?: boolean;
+  joinDisabled?: boolean;
+  joinLabel?: string;
 }
 
 const roomTypeStyleMap = {
@@ -36,11 +41,23 @@ const roomTypeStyleMap = {
   },
 } as const;
 
-const RoomCard = ({ room, isSelected, onClick }: RoomCardProps) => {
+const RoomCard = ({
+  room,
+  isSelected,
+  onClick,
+  onJoinClick,
+  isJoinPending = false,
+  joinDisabled = false,
+  joinLabel = '참여하기',
+}: RoomCardProps) => {
   const { badgeClassName, badgeLabel, buttonClassName, cardClassName, progressClassName } =
     roomTypeStyleMap[room.roomType];
   const progressPercent = (room.currentCount / room.capacity) * 100;
   const remainingCount = room.capacity - room.currentCount;
+  const handleJoinButtonClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onJoinClick(room.id);
+  };
 
   return (
     <article
@@ -93,12 +110,15 @@ const RoomCard = ({ room, isSelected, onClick }: RoomCardProps) => {
 
           <button
             type="button"
+            onClick={handleJoinButtonClick}
+            disabled={joinDisabled || isJoinPending}
             className={cn(
               'mt-4 w-full rounded-2xl px-4 py-3.5 text-sm font-semibold transition',
+              joinDisabled || isJoinPending ? 'cursor-not-allowed opacity-70' : '',
               buttonClassName,
             )}
           >
-            참여하기
+            {isJoinPending ? '참여 중...' : joinLabel}
           </button>
         </div>
       </div>

--- a/src/shared/api/rooms/index.ts
+++ b/src/shared/api/rooms/index.ts
@@ -2,7 +2,8 @@ export type {
   CreateRoomRequest,
   GetRoomsResponse,
   RoomDetailResponse,
+  RoomJoinResponse,
   RoomListItemResponse,
 } from './rooms';
-export { createRoom, getRoomDetail, getRooms } from './rooms';
+export { createRoom, getRoomDetail, getRooms, joinRoom } from './rooms';
 export { roomQueries } from './roomsQueries';

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -49,6 +49,12 @@ export interface CreateRoomRequest {
   maxAge: number;
 }
 
+export interface RoomJoinResponse {
+  roomId: number;
+  userId: number;
+  createdAt: string;
+}
+
 export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsResponse> {
   const response = await client.get<GetRoomsResponse>('/api/v1/rooms', {
     params: {
@@ -70,6 +76,12 @@ export async function getRoomDetail(roomId: number): Promise<RoomDetailResponse>
 
 export async function createRoom(payload: CreateRoomRequest): Promise<RoomDetailResponse> {
   const response = await client.post<RoomDetailResponse>('/api/v1/rooms', payload);
+
+  return response.data;
+}
+
+export async function joinRoom(roomId: number): Promise<RoomJoinResponse> {
+  const response = await client.post<RoomJoinResponse>(`/api/v1/rooms/${roomId}/join`);
 
   return response.data;
 }


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 카드의 참여 버튼을 API 명세서 기준 `POST /api/v1/rooms/{roomId}/join` 흐름과 연결했습니다.
- 로그인하지 않은 사용자가 참여 버튼을 누르면 로그인 모달을 먼저 여는 방식으로 ROOM 참여 UX를 정리했습니다.
- 참여 성공/실패에 따른 ROOM 목록, 상세, 공용 메시지 상태를 프론트에서 먼저 준비해 두었습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts`에 `joinRoom(roomId)`와 `RoomJoinResponse` 추가
- `src/shared/api/rooms/index.ts` export 정리
- `src/pages/main/ui/layout/MainPage.tsx`에서 ROOM 참여 시 로그인 모달을 열 수 있도록 콜백 연결
- `src/pages/main/ui/layout/MainTabSection.tsx`에 join mutation, 성공/실패 메시지, 목록/상세 invalidate 처리 추가
- `src/pages/main/ui/room/RoomCard.tsx`에 참여 버튼 액션 props와 pending/disabled/label 처리 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 ROOM 참여 흐름을 프론트에서 먼저 준비하는 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 비로그인 상태에서는 참여 요청을 보내지 않고 로그인 모달을 먼저 엽니다.
- join 성공 후에는 새 화면 이동 없이 ROOM 목록/상세 query invalidate로 최신 상태만 반영합니다.
- 목록에서는 `currentCount >= capacity`를 기준으로 `정원 마감` 상태를 프론트에서 계산해 버튼을 비활성화합니다.
- 현재 로컬 환경에는 `node_modules`가 없어 `pnpm build`, `pnpm lint`는 아직 실행하지 못했습니다.

## 🧐 이슈 (Related Issues)

- Closes #70
