### PR TITLE
feat: (#71) 방 나가기 연결

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -9,7 +9,7 @@ import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
-import { joinRoom } from '@/shared/api/rooms/rooms';
+import { joinRoom, leaveRoom } from '@/shared/api/rooms/rooms';
 import { roomQueries } from '@/shared/api/rooms/roomsQueries';
 import { cn } from '@/shared/lib/utils';
 import {
@@ -46,7 +46,7 @@ const tabDescriptionMap: Record<MainTab, string> = {
   BOARD: '자유게시판에서 점심메이트와 가볍게 소통해보세요.',
 };
 
-const getJoinErrorMessage = (error: unknown) => {
+const getRoomActionErrorMessage = (error: unknown, action: 'join' | 'leave') => {
   if (isAxiosError<ApiErrorPayload>(error)) {
     const responseMessage = error.response?.data?.message;
 
@@ -59,7 +59,7 @@ const getJoinErrorMessage = (error: unknown) => {
     }
 
     if (error.response?.status === 403) {
-      return '참여할 수 없는 방이에요.';
+      return action === 'leave' ? '나갈 수 없는 방이에요.' : '참여할 수 없는 방이에요.';
     }
 
     if (error.response?.status === 404) {
@@ -67,7 +67,9 @@ const getJoinErrorMessage = (error: unknown) => {
     }
 
     if (error.response?.status === 409) {
-      return '이미 다른 방에 참여 중이거나 이미 참여한 방이에요.';
+      return action === 'leave'
+        ? '이미 나간 방이거나 나갈 수 없는 상태예요.'
+        : '이미 다른 방에 참여 중이거나 이미 참여한 방이에요.';
     }
   }
 
@@ -75,7 +77,9 @@ const getJoinErrorMessage = (error: unknown) => {
     return error.message;
   }
 
-  return '방 참여에 실패했어요. 잠시 후 다시 시도해 주세요.';
+  return action === 'leave'
+    ? '방 나가기에 실패했어요. 잠시 후 다시 시도해 주세요.'
+    : '방 참여에 실패했어요. 잠시 후 다시 시도해 주세요.';
 };
 
 const MainTabSection = ({
@@ -126,7 +130,31 @@ const MainTabSection = ({
         return;
       }
 
-      setRoomActionMessage(getJoinErrorMessage(error));
+      setRoomActionMessage(getRoomActionErrorMessage(error, 'join'));
+      setRoomActionMessageTone('error');
+    },
+  });
+  const leaveRoomMutation = useMutation({
+    mutationFn: leaveRoom,
+    onSuccess: async (_, roomId) => {
+      setJoinedRoomId((currentRoomId) => (currentRoomId === roomId ? null : currentRoomId));
+      setRoomActionMessage('방에서 나갔어요.');
+      setRoomActionMessageTone('success');
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: roomQueries.lists() }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.detail(roomId).queryKey }),
+      ]);
+    },
+    onError: (error) => {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        setRoomActionMessage('로그인 후 방을 나갈 수 있어요.');
+        setRoomActionMessageTone('error');
+        onJoinRequireLogin();
+        return;
+      }
+
+      setRoomActionMessage(getRoomActionErrorMessage(error, 'leave'));
       setRoomActionMessageTone('error');
     },
   });
@@ -160,6 +188,17 @@ const MainTabSection = ({
 
     setRoomActionMessage('');
     joinRoomMutation.mutate(roomId);
+  };
+  const handleLeaveClick = (roomId: number) => {
+    if (!isAuthenticated()) {
+      setRoomActionMessage('로그인 후 방을 나갈 수 있어요.');
+      setRoomActionMessageTone('error');
+      onJoinRequireLogin();
+      return;
+    }
+
+    setRoomActionMessage('');
+    leaveRoomMutation.mutate(roomId);
   };
 
   const hasJoinedActiveRoom = joinedRoomId !== null;
@@ -326,17 +365,22 @@ const MainTabSection = ({
             ? rooms.map((room) => {
                 const isJoinPending =
                   joinRoomMutation.isPending && joinRoomMutation.variables === room.id;
+                const isLeavePending =
+                  leaveRoomMutation.isPending && leaveRoomMutation.variables === room.id;
+                const isActionPending = isJoinPending || isLeavePending;
                 const isFullRoom = room.currentCount >= room.capacity;
                 const isJoinedRoom = joinedRoomId === room.id;
-                const joinDisabled =
-                  isFullRoom || isJoinPending || (hasJoinedActiveRoom && !isJoinedRoom);
-                const joinLabel = isFullRoom
-                  ? '정원 마감'
-                  : isJoinedRoom
-                    ? '참여 완료'
+                const actionDisabled = isJoinedRoom
+                  ? isActionPending
+                  : isFullRoom || isActionPending || hasJoinedActiveRoom;
+                const actionLabel = isJoinedRoom
+                  ? '나가기'
+                  : isFullRoom
+                    ? '정원 마감'
                     : hasJoinedActiveRoom
                       ? '다른 방 참여 중'
                       : '참여하기';
+                const handleRoomActionClick = isJoinedRoom ? handleLeaveClick : handleJoinClick;
 
                 return (
                   <RoomCard
@@ -344,10 +388,10 @@ const MainTabSection = ({
                     room={room}
                     isSelected={selectedRoomId === room.id}
                     onClick={() => setSelectedRoomId(room.id)}
-                    onJoinClick={handleJoinClick}
-                    isJoinPending={isJoinPending}
-                    joinDisabled={joinDisabled}
-                    joinLabel={joinLabel}
+                    onActionClick={handleRoomActionClick}
+                    isActionPending={isActionPending}
+                    actionDisabled={actionDisabled}
+                    actionLabel={actionLabel}
                   />
                 );
               })

--- a/src/pages/main/ui/room/RoomCard.tsx
+++ b/src/pages/main/ui/room/RoomCard.tsx
@@ -8,10 +8,10 @@ interface RoomCardProps {
   room: MainRoom;
   isSelected: boolean;
   onClick: () => void;
-  onJoinClick: (roomId: number) => void;
-  isJoinPending?: boolean;
-  joinDisabled?: boolean;
-  joinLabel?: string;
+  onActionClick: (roomId: number) => void;
+  isActionPending?: boolean;
+  actionDisabled?: boolean;
+  actionLabel?: string;
 }
 
 const roomTypeStyleMap = {
@@ -45,18 +45,18 @@ const RoomCard = ({
   room,
   isSelected,
   onClick,
-  onJoinClick,
-  isJoinPending = false,
-  joinDisabled = false,
-  joinLabel = '참여하기',
+  onActionClick,
+  isActionPending = false,
+  actionDisabled = false,
+  actionLabel = '참여하기',
 }: RoomCardProps) => {
   const { badgeClassName, badgeLabel, buttonClassName, cardClassName, progressClassName } =
     roomTypeStyleMap[room.roomType];
   const progressPercent = (room.currentCount / room.capacity) * 100;
   const remainingCount = room.capacity - room.currentCount;
-  const handleJoinButtonClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleActionButtonClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    onJoinClick(room.id);
+    onActionClick(room.id);
   };
 
   return (
@@ -110,15 +110,15 @@ const RoomCard = ({
 
           <button
             type="button"
-            onClick={handleJoinButtonClick}
-            disabled={joinDisabled || isJoinPending}
+            onClick={handleActionButtonClick}
+            disabled={actionDisabled || isActionPending}
             className={cn(
               'mt-4 w-full rounded-2xl px-4 py-3.5 text-sm font-semibold transition',
-              joinDisabled || isJoinPending ? 'cursor-not-allowed opacity-70' : '',
+              actionDisabled || isActionPending ? 'cursor-not-allowed opacity-70' : '',
               buttonClassName,
             )}
           >
-            {isJoinPending ? '참여 중...' : joinLabel}
+            {isActionPending ? '처리 중...' : actionLabel}
           </button>
         </div>
       </div>

--- a/src/shared/api/rooms/index.ts
+++ b/src/shared/api/rooms/index.ts
@@ -5,5 +5,5 @@ export type {
   RoomJoinResponse,
   RoomListItemResponse,
 } from './rooms';
-export { createRoom, getRoomDetail, getRooms, joinRoom } from './rooms';
+export { createRoom, getRoomDetail, getRooms, joinRoom, leaveRoom } from './rooms';
 export { roomQueries } from './roomsQueries';

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -85,3 +85,7 @@ export async function joinRoom(roomId: number): Promise<RoomJoinResponse> {
 
   return response.data;
 }
+
+export async function leaveRoom(roomId: number): Promise<void> {
+  await client.post(`/api/v1/rooms/${roomId}/leave`);
+}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 탭에서 방 나가기 액션을 `POST /api/v1/rooms/{roomId}/leave` 흐름에 맞춰 연결했습니다.
- 참여/나가기 버튼을 하나의 액션 버튼 흐름으로 정리해, 참여 중인 방에서는 `나가기`, 그 외에는 `참여하기`가 보이도록 구성했습니다.
- 나가기 성공/실패 후 ROOM 목록, 상세, 공용 메시지 상태가 자연스럽게 갱신되도록 정리했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts`에 `leaveRoom(roomId)` 추가
- `src/shared/api/rooms/index.ts` export 정리
- `src/pages/main/ui/layout/MainTabSection.tsx`에 leave mutation, 성공/실패 메시지, 목록/상세 invalidate 처리 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`에서 참여/나가기 버튼 흐름 통합
- `src/pages/main/ui/room/RoomCard.tsx`의 버튼 props를 범용 액션 형태로 정리

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 ROOM 나가기 액션과 참여/나가기 버튼 흐름 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 비로그인 상태에서는 나가기 요청을 보내지 않고 로그인 모달을 먼저 엽니다.
- 나가기 성공 후에는 새 화면 이동 없이 ROOM 목록/상세 query invalidate로 최신 상태만 반영합니다.
- `401 / 403 / 404 / 409` 응답에 따라 ROOM 탭 공용 메시지 영역에 안내 문구를 표시합니다.
- 현재 참여 여부는 `joinedRoomId` 상태를 기준으로 관리하므로, 새로고침 후 이미 참여 중인 방을 복원하는 처리는 이번 범위에 포함하지 않았습니다.
- 현재 로컬 환경에는 `node_modules`가 없어 `pnpm build`, `pnpm lint`는 아직 실행하지 못했습니다.

## 🧐 이슈 (Related Issues)

- Closes #71
