### PR TITLE
feat: (#72) 방 멤버 조회 연결

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -82,6 +82,24 @@ const getRoomActionErrorMessage = (error: unknown, action: 'join' | 'leave') => 
     : '방 참여에 실패했어요. 잠시 후 다시 시도해 주세요.';
 };
 
+const getRoomMembersErrorMessage = (error: unknown) => {
+  if (isAxiosError<ApiErrorPayload>(error)) {
+    if (error.response?.status === 401) {
+      return '로그인 후 멤버를 확인할 수 있어요.';
+    }
+
+    if (error.response?.status === 403) {
+      return '멤버를 확인할 수 없어요.';
+    }
+
+    if (error.response?.status === 404) {
+      return '방을 찾을 수 없어요.';
+    }
+  }
+
+  return '멤버 목록을 불러오지 못했어요.';
+};
+
 const MainTabSection = ({
   activeTab,
   onCreateRoomClick,
@@ -110,6 +128,15 @@ const MainTabSection = ({
     ...roomQueries.detail(selectedRoomId ?? 0),
     enabled: isRoomTab && selectedRoomId !== null,
   });
+  const {
+    data: roomMembersData,
+    isLoading: isRoomMembersLoading,
+    isError: isRoomMembersError,
+    error: roomMembersError,
+  } = useQuery({
+    ...roomQueries.members(selectedRoomId ?? 0),
+    enabled: isRoomTab && selectedRoomId !== null && roomDetail !== undefined,
+  });
   const joinRoomMutation = useMutation({
     mutationFn: joinRoom,
     onSuccess: async ({ roomId }) => {
@@ -120,6 +147,7 @@ const MainTabSection = ({
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: roomQueries.lists() }),
         queryClient.invalidateQueries({ queryKey: roomQueries.detail(roomId).queryKey }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.members(roomId).queryKey }),
       ]);
     },
     onError: (error) => {
@@ -144,6 +172,7 @@ const MainTabSection = ({
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: roomQueries.lists() }),
         queryClient.invalidateQueries({ queryKey: roomQueries.detail(roomId).queryKey }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.members(roomId).queryKey }),
       ]);
     },
     onError: (error) => {
@@ -202,6 +231,7 @@ const MainTabSection = ({
   };
 
   const hasJoinedActiveRoom = joinedRoomId !== null;
+  const roomMembers = roomMembersData?.items ?? [];
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -476,6 +506,59 @@ const MainTabSection = ({
                   </div>
                 </section>
               </div>
+
+              <section className="mt-6 rounded-[24px] bg-slate-50 px-5 py-5">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <h4 className="text-sm font-semibold text-slate-700">멤버 목록</h4>
+                    <p className="mt-1 text-xs text-slate-500">현재 참여 중인 멤버를 확인할 수 있어요.</p>
+                  </div>
+                  <div className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-600">
+                    <Users className="h-3.5 w-3.5 text-slate-500" />
+                    {getDetailRoomCurrentCount(roomDetail)}명
+                  </div>
+                </div>
+
+                {isRoomMembersLoading ? (
+                  <div className="mt-4 rounded-2xl bg-white px-4 py-4 text-sm text-slate-500">
+                    멤버 목록을 불러오는 중...
+                  </div>
+                ) : null}
+
+                {isRoomMembersError ? (
+                  <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-600">
+                    {getRoomMembersErrorMessage(roomMembersError)}
+                  </div>
+                ) : null}
+
+                {!isRoomMembersLoading && !isRoomMembersError && roomMembers.length === 0 ? (
+                  <div className="mt-4 rounded-2xl bg-white px-4 py-4 text-sm text-slate-500">
+                    아직 참여한 멤버가 없어요.
+                  </div>
+                ) : null}
+
+                {!isRoomMembersLoading && !isRoomMembersError && roomMembers.length > 0 ? (
+                  <ul className="mt-4 space-y-3">
+                    {roomMembers.map((member) => {
+                      const isHost = roomDetail.hostUserId === member.userId;
+
+                      return (
+                        <li
+                          key={member.userId}
+                          className="flex items-center justify-between rounded-2xl bg-white px-4 py-3"
+                        >
+                          <span className="text-sm font-medium text-slate-700">{member.nickname}</span>
+                          {isHost ? (
+                            <span className="rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
+                              방장
+                            </span>
+                          ) : null}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : null}
+              </section>
             </article>
           ) : null}
         </>

--- a/src/shared/api/rooms/index.ts
+++ b/src/shared/api/rooms/index.ts
@@ -1,9 +1,11 @@
 export type {
   CreateRoomRequest,
+  GetRoomMembersResponse,
   GetRoomsResponse,
   RoomDetailResponse,
   RoomJoinResponse,
   RoomListItemResponse,
+  RoomMemberResponse,
 } from './rooms';
-export { createRoom, getRoomDetail, getRooms, joinRoom, leaveRoom } from './rooms';
+export { createRoom, getRoomDetail, getRoomMembers, getRooms, joinRoom, leaveRoom } from './rooms';
 export { roomQueries } from './roomsQueries';

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -55,6 +55,15 @@ export interface RoomJoinResponse {
   createdAt: string;
 }
 
+export interface RoomMemberResponse {
+  userId: number;
+  nickname: string;
+}
+
+export interface GetRoomMembersResponse {
+  items: RoomMemberResponse[];
+}
+
 export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsResponse> {
   const response = await client.get<GetRoomsResponse>('/api/v1/rooms', {
     params: {
@@ -70,6 +79,12 @@ export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsR
 
 export async function getRoomDetail(roomId: number): Promise<RoomDetailResponse> {
   const response = await client.get<RoomDetailResponse>(`/api/v1/rooms/${roomId}`);
+
+  return response.data;
+}
+
+export async function getRoomMembers(roomId: number): Promise<GetRoomMembersResponse> {
+  const response = await client.get<GetRoomMembersResponse>(`/api/v1/rooms/${roomId}/members`);
 
   return response.data;
 }

--- a/src/shared/api/rooms/roomsQueries.ts
+++ b/src/shared/api/rooms/roomsQueries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from '@tanstack/react-query';
-import { getRoomDetail, getRooms, type RoomListFilters } from '@/shared/api/rooms/rooms';
+import { getRoomDetail, getRoomMembers, getRooms, type RoomListFilters } from '@/shared/api/rooms/rooms';
 
 export const roomQueries = {
   all: () => ['rooms'] as const,
@@ -14,5 +14,11 @@ export const roomQueries = {
     queryOptions({
       queryKey: [...roomQueries.details(), roomId],
       queryFn: () => getRoomDetail(roomId),
+    }),
+  membersAll: () => [...roomQueries.all(), 'members'] as const,
+  members: (roomId: number) =>
+    queryOptions({
+      queryKey: [...roomQueries.membersAll(), roomId],
+      queryFn: () => getRoomMembers(roomId),
     }),
 };


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 상세 영역에서 방 멤버 목록 조회를 실제 `GET /api/v1/rooms/{roomId}/members` 흐름에 맞춰 연결했습니다.
- 멤버 UI는 닉네임 중심의 간단 리스트로 구성하고, 상세 응답의 `hostUserId`를 기준으로 `방장` 표시를 추가했습니다.
- 멤버 조회 상태는 ROOM 공용 액션 메시지와 분리해서, 상세 내부에서 loading / empty / error 상태를 각각 확인할 수 있도록 정리했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts`에 `getRoomMembers(roomId)`, `RoomMemberResponse`, `GetRoomMembersResponse` 추가
- `src/shared/api/rooms/index.ts` export 정리
- `src/shared/api/rooms/roomsQueries.ts`에 `roomQueries.members(roomId)` query-factory 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`에서 선택된 방의 멤버 목록 조회 연결
- `src/pages/main/ui/layout/MainTabSection.tsx` 상세 하단에 멤버 목록 섹션과 loading / empty / error UI 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`에서 join / leave 성공 후 멤버 목록 query도 함께 invalidate 되도록 정리

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 ROOM 상세의 멤버 목록 연결과 상태 표시 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 멤버 목록은 닉네임 중심의 간단 리스트만 제공하며, MBTI / 학교 / 소개 같은 확장 정보는 이번 범위에 포함하지 않았습니다.
- 방장 여부는 멤버 응답이 아니라 상세 응답의 `hostUserId`를 기준으로 프론트에서 계산합니다.
- 멤버 조회 에러는 ROOM 탭 공용 메시지가 아니라 상세 내부 섹션에서만 표시합니다.
- `401 / 403 / 404` 상태에 따라 멤버 섹션 안내 문구를 구분해 보여줍니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #72
