### PR TITLE
feat: (#73) 방 멤버 강퇴 연결

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -9,8 +9,9 @@ import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
-import { joinRoom, leaveRoom } from '@/shared/api/rooms/rooms';
+import { joinRoom, kickRoomMember, leaveRoom } from '@/shared/api/rooms/rooms';
 import { roomQueries } from '@/shared/api/rooms/roomsQueries';
+import { myUserQueryOptions } from '@/shared/api/users/meQueries';
 import { cn } from '@/shared/lib/utils';
 import {
   detailRoomStatusStyleMap,
@@ -100,6 +101,38 @@ const getRoomMembersErrorMessage = (error: unknown) => {
   return '멤버 목록을 불러오지 못했어요.';
 };
 
+const getKickMemberErrorMessage = (error: unknown) => {
+  if (isAxiosError<ApiErrorPayload>(error)) {
+    const responseMessage = error.response?.data?.message;
+
+    if (Array.isArray(responseMessage) && responseMessage.length > 0) {
+      return responseMessage.join(' ');
+    }
+
+    if (typeof responseMessage === 'string' && responseMessage.trim() !== '') {
+      return responseMessage;
+    }
+
+    if (error.response?.status === 403) {
+      return '강퇴할 권한이 없어요.';
+    }
+
+    if (error.response?.status === 404) {
+      return '방 또는 멤버를 찾을 수 없어요.';
+    }
+
+    if (error.response?.status === 409) {
+      return '강퇴할 수 없는 상태예요.';
+    }
+  }
+
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+
+  return '멤버 강퇴에 실패했어요. 잠시 후 다시 시도해 주세요.';
+};
+
 const MainTabSection = ({
   activeTab,
   onCreateRoomClick,
@@ -115,9 +148,14 @@ const MainTabSection = ({
     'success',
   );
   const roomFilters = toRoomListFilters(roomFilterState);
+  const isLoggedIn = isAuthenticated();
   const { data, isLoading, isError, error } = useQuery({
     ...roomQueries.list(roomFilters),
     enabled: isRoomTab,
+  });
+  const { data: currentUser } = useQuery({
+    ...myUserQueryOptions(),
+    enabled: isRoomTab && isLoggedIn,
   });
   const {
     data: roomDetail,
@@ -187,6 +225,30 @@ const MainTabSection = ({
       setRoomActionMessageTone('error');
     },
   });
+  const kickRoomMemberMutation = useMutation({
+    mutationFn: kickRoomMember,
+    onSuccess: async (_, variables) => {
+      setRoomActionMessage('멤버를 강퇴했어요.');
+      setRoomActionMessageTone('success');
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: roomQueries.lists() }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.detail(variables.roomId).queryKey }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.members(variables.roomId).queryKey }),
+      ]);
+    },
+    onError: (error) => {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        setRoomActionMessage('로그인 후 강퇴할 수 있어요.');
+        setRoomActionMessageTone('error');
+        onJoinRequireLogin();
+        return;
+      }
+
+      setRoomActionMessage(getKickMemberErrorMessage(error));
+      setRoomActionMessageTone('error');
+    },
+  });
   const rooms = data?.items.map(toMainRoom) ?? [];
 
   useEffect(() => {
@@ -232,6 +294,8 @@ const MainTabSection = ({
 
   const hasJoinedActiveRoom = joinedRoomId !== null;
   const roomMembers = roomMembersData?.items ?? [];
+  const currentUserId = currentUser?.id ?? null;
+  const isHostUser = roomDetail !== undefined && currentUserId === roomDetail.hostUserId;
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -541,6 +605,11 @@ const MainTabSection = ({
                   <ul className="mt-4 space-y-3">
                     {roomMembers.map((member) => {
                       const isHost = roomDetail.hostUserId === member.userId;
+                      const isKickPending =
+                        kickRoomMemberMutation.isPending &&
+                        kickRoomMemberMutation.variables?.roomId === roomDetail.id &&
+                        kickRoomMemberMutation.variables?.userId === member.userId;
+                      const canKickMember = isHostUser && !isHost;
 
                       return (
                         <li
@@ -548,11 +617,34 @@ const MainTabSection = ({
                           className="flex items-center justify-between rounded-2xl bg-white px-4 py-3"
                         >
                           <span className="text-sm font-medium text-slate-700">{member.nickname}</span>
-                          {isHost ? (
-                            <span className="rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
-                              방장
-                            </span>
-                          ) : null}
+                          <div className="flex items-center gap-2">
+                            {isHost ? (
+                              <span className="rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
+                                방장
+                              </span>
+                            ) : null}
+                            {canKickMember ? (
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setRoomActionMessage('');
+                                  kickRoomMemberMutation.mutate({
+                                    roomId: roomDetail.id,
+                                    userId: member.userId,
+                                  });
+                                }}
+                                disabled={isKickPending}
+                                className={cn(
+                                  'rounded-full px-3 py-1 text-xs font-semibold transition',
+                                  isKickPending
+                                    ? 'cursor-not-allowed bg-slate-200 text-slate-500'
+                                    : 'bg-rose-100 text-rose-600 hover:bg-rose-200',
+                                )}
+                              >
+                                {isKickPending ? '강퇴 중...' : '강퇴'}
+                              </button>
+                            ) : null}
+                          </div>
                         </li>
                       );
                     })}

--- a/src/shared/api/rooms/index.ts
+++ b/src/shared/api/rooms/index.ts
@@ -2,10 +2,19 @@ export type {
   CreateRoomRequest,
   GetRoomMembersResponse,
   GetRoomsResponse,
+  KickRoomMemberRequest,
   RoomDetailResponse,
   RoomJoinResponse,
   RoomListItemResponse,
   RoomMemberResponse,
 } from './rooms';
-export { createRoom, getRoomDetail, getRoomMembers, getRooms, joinRoom, leaveRoom } from './rooms';
+export {
+  createRoom,
+  getRoomDetail,
+  getRoomMembers,
+  getRooms,
+  joinRoom,
+  kickRoomMember,
+  leaveRoom,
+} from './rooms';
 export { roomQueries } from './roomsQueries';

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -64,6 +64,11 @@ export interface GetRoomMembersResponse {
   items: RoomMemberResponse[];
 }
 
+export interface KickRoomMemberRequest {
+  roomId: number;
+  userId: number;
+}
+
 export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsResponse> {
   const response = await client.get<GetRoomsResponse>('/api/v1/rooms', {
     params: {
@@ -103,4 +108,8 @@ export async function joinRoom(roomId: number): Promise<RoomJoinResponse> {
 
 export async function leaveRoom(roomId: number): Promise<void> {
   await client.post(`/api/v1/rooms/${roomId}/leave`);
+}
+
+export async function kickRoomMember({ roomId, userId }: KickRoomMemberRequest): Promise<void> {
+  await client.delete(`/api/v1/rooms/${roomId}/members/${userId}`);
 }

--- a/src/shared/api/users/me.ts
+++ b/src/shared/api/users/me.ts
@@ -1,0 +1,8 @@
+import type { GetMeResponse } from '@/shared/types/user';
+import client from '@/shared/api/client';
+
+export async function getMe(): Promise<GetMeResponse> {
+  const response = await client.get<GetMeResponse>('/api/v1/users/me');
+
+  return response.data;
+}

--- a/src/shared/api/users/meQueries.ts
+++ b/src/shared/api/users/meQueries.ts
@@ -1,0 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getMe } from '@/shared/api/users/me';
+
+export const myUserQueryOptions = () =>
+  queryOptions({
+    queryKey: ['myUser'],
+    queryFn: getMe,
+  });

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -1,0 +1,3 @@
+export interface GetMeResponse {
+  id: number;
+}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 상세 멤버 목록에서 방장 전용 강퇴 액션을 실제 `DELETE /api/v1/rooms/{roomId}/members/{userId}` 흐름에 맞춰 연결했습니다.
- 현재 사용자 조회(`/api/v1/users/me`)를 추가하고, `hostUserId`와 비교해 방장에게만 강퇴 버튼이 보이도록 구성했습니다.
- 강퇴 성공 후 ROOM 목록, 상세, 멤버 목록을 다시 불러오고, 공용 메시지 영역에서 성공/실패 상태를 확인할 수 있도록 정리했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/users/me.ts`, `src/shared/api/users/meQueries.ts`, `src/shared/types/user.ts` 추가
- `src/shared/api/rooms/rooms.ts`에 `kickRoomMember`와 요청 타입 추가
- `src/shared/api/rooms/index.ts` export 정리
- `src/pages/main/ui/layout/MainTabSection.tsx`에 host-only 강퇴 버튼, pending 상태, 성공/실패 메시지, invalidate 처리 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 ROOM 상세의 방장 전용 강퇴 액션 연결과 후속 상태 갱신 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 방장만 강퇴 버튼을 볼 수 있고, 방장 본인 행에는 버튼이 보이지 않습니다.
- 강퇴는 확인 모달 없이 즉시 호출되며, pending 중에는 대상 멤버 행의 버튼만 비활성화합니다.
- `401 / 403 / 404 / 409` 실패는 ROOM 공용 메시지 영역에서 처리합니다.
- 멤버 프로필 확장 정보와 새로고침 후 참여 상태 복원은 이번 범위에 포함하지 않았습니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #73
