### PR TITLE
feat: (#74) 방 수정 연결

### DIFF
--- a/src/pages/main/ui/layout/MainPage.tsx
+++ b/src/pages/main/ui/layout/MainPage.tsx
@@ -30,6 +30,7 @@ const MainPage = () => {
       <CreateRoomModal
         isOpen={isCreateRoomModalOpen}
         onClose={() => setIsCreateRoomModalOpen(false)}
+        onRequireLogin={() => setIsLoginModalOpen(true)}
       />
     </div>
   );

--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -7,6 +7,7 @@ import type { MainTab } from '../../model/types';
 import MainBoardSection from '../board/MainBoardSection';
 import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
+import CreateRoomModal, { toCreateRoomFormState } from '../room/CreateRoomModal';
 import RoomCard from '../room/RoomCard';
 import RoomSummary from '../room/RoomSummary';
 import { joinRoom, kickRoomMember, leaveRoom } from '@/shared/api/rooms/rooms';
@@ -143,6 +144,7 @@ const MainTabSection = ({
   const [roomFilterState, setRoomFilterState] = useState<RoomFilterState>(INITIAL_ROOM_FILTER_STATE);
   const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
   const [joinedRoomId, setJoinedRoomId] = useState<number | null>(null);
+  const [isEditRoomModalOpen, setIsEditRoomModalOpen] = useState(false);
   const [roomActionMessage, setRoomActionMessage] = useState('');
   const [roomActionMessageTone, setRoomActionMessageTone] = useState<'success' | 'error'>(
     'success',
@@ -550,6 +552,18 @@ const MainTabSection = ({
                   <div className="mt-2 rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-600">
                     {roomDetail.minAge}-{roomDetail.maxAge}대
                   </div>
+                  {isHostUser ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setRoomActionMessage('');
+                        setIsEditRoomModalOpen(true);
+                      }}
+                      className="mt-4 w-full rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+                    >
+                      방 수정
+                    </button>
+                  ) : null}
                 </div>
               </div>
 
@@ -654,6 +668,25 @@ const MainTabSection = ({
             </article>
           ) : null}
         </>
+      ) : null}
+
+      {roomDetail ? (
+        <CreateRoomModal
+          isOpen={isEditRoomModalOpen}
+          onClose={() => setIsEditRoomModalOpen(false)}
+          mode="edit"
+          roomId={roomDetail.id}
+          initialValues={toCreateRoomFormState(roomDetail)}
+          onRequireLogin={onJoinRequireLogin}
+          onSuccess={() => {
+            setRoomActionMessage('방 정보를 수정했어요.');
+            setRoomActionMessageTone('success');
+          }}
+          onError={(message) => {
+            setRoomActionMessage(message);
+            setRoomActionMessageTone('error');
+          }}
+        />
       ) : null}
 
       {activeTab === 'LUNCH' ? <MainLunchMenuSection /> : null}

--- a/src/pages/main/ui/room/CreateRoomModal.tsx
+++ b/src/pages/main/ui/room/CreateRoomModal.tsx
@@ -3,12 +3,18 @@ import { isAxiosError } from 'axios';
 import { useForm } from '@tanstack/react-form';
 import { X } from 'lucide-react';
 import { useEffect, useRef, useState, type MouseEvent } from 'react';
-import { createRoom } from '@/shared/api/rooms/rooms';
+import { createRoom, updateRoom, type RoomDetailResponse } from '@/shared/api/rooms/rooms';
 import { roomQueries } from '@/shared/api/rooms/roomsQueries';
 
 interface CreateRoomModalProps {
   isOpen: boolean;
   onClose: () => void;
+  mode?: 'create' | 'edit';
+  roomId?: number;
+  initialValues?: CreateRoomFormState;
+  onSuccess?: () => void;
+  onError?: (message: string) => void;
+  onRequireLogin?: () => void;
 }
 
 interface CreateRoomFormState {
@@ -36,6 +42,17 @@ const INITIAL_CREATE_ROOM_FORM_STATE: CreateRoomFormState = {
   minAge: '20',
   maxAge: '24',
 };
+
+const toCreateRoomFormState = (room: RoomDetailResponse): CreateRoomFormState => ({
+  title: room.title,
+  description: room.description ?? '',
+  roomType: room.roomType === 'MALE' || room.roomType === 'FEMALE' ? room.roomType : 'MIXED',
+  capacity: String(room.maxMembersCount),
+  place: room.place,
+  lunchAt: formatLunchAtForForm(room.lunchAt),
+  minAge: String(room.minAge),
+  maxAge: String(room.maxAge),
+});
 
 const parseRequiredNumber = (value: string) => {
   const trimmedValue = value.trim();
@@ -85,7 +102,17 @@ const toFutureLunchAt = (timeValue: string) => {
   return lunchAt.toISOString();
 };
 
-const getCreateRoomErrorMessage = (error: unknown) => {
+function formatLunchAtForForm(lunchAt: string) {
+  const timeMatch = lunchAt.match(/(?:T|\s)?(\d{2}:\d{2})/);
+
+  if (timeMatch) {
+    return timeMatch[1];
+  }
+
+  return '12:00';
+}
+
+const getRoomSubmitErrorMessage = (error: unknown, mode: 'create' | 'edit') => {
   if (isAxiosError<ApiErrorPayload>(error)) {
     const responseMessage = error.response?.data?.message;
 
@@ -96,20 +123,52 @@ const getCreateRoomErrorMessage = (error: unknown) => {
     if (typeof responseMessage === 'string' && responseMessage.trim() !== '') {
       return responseMessage;
     }
+
+    if (error.response?.status === 401) {
+      return mode === 'edit'
+        ? '로그인 후 방을 수정할 수 있어요.'
+        : '로그인 후 방을 만들 수 있어요.';
+    }
+
+    if (mode === 'edit') {
+      if (error.response?.status === 403) {
+        return '방을 수정할 권한이 없어요.';
+      }
+
+      if (error.response?.status === 404) {
+        return '방을 찾을 수 없어요.';
+      }
+
+      if (error.response?.status === 409) {
+        return '수정할 수 없는 상태예요.';
+      }
+    }
   }
 
   if (error instanceof Error && error.message.trim() !== '') {
     return error.message;
   }
 
-  return '방 만들기에 실패했어요. 잠시 후 다시 시도해 주세요.';
+  return mode === 'edit'
+    ? '방 수정에 실패했어요. 잠시 후 다시 시도해 주세요.'
+    : '방 만들기에 실패했어요. 잠시 후 다시 시도해 주세요.';
 };
 
-const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
+const CreateRoomModal = ({
+  isOpen,
+  onClose,
+  mode = 'create',
+  roomId,
+  initialValues,
+  onSuccess,
+  onError,
+  onRequireLogin,
+}: CreateRoomModalProps) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const queryClient = useQueryClient();
   const [submitMessage, setSubmitMessage] = useState('');
   const [submitMessageTone, setSubmitMessageTone] = useState<'error' | 'success'>('success');
+  const isEditMode = mode === 'edit';
 
   const createRoomMutation = useMutation({
     mutationFn: createRoom,
@@ -119,11 +178,42 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
         queryClient.invalidateQueries({ queryKey: roomQueries.details() }),
       ]);
 
+      onSuccess?.();
       handleClose();
     },
     onError: (error) => {
-      setSubmitMessage(getCreateRoomErrorMessage(error));
+      if (isAxiosError(error) && error.response?.status === 401) {
+        onRequireLogin?.();
+      }
+
+      const message = getRoomSubmitErrorMessage(error, 'create');
+      setSubmitMessage(message);
       setSubmitMessageTone('error');
+      onError?.(message);
+    },
+  });
+  const updateRoomMutation = useMutation({
+    mutationFn: ({ targetRoomId, payload }: { targetRoomId: number; payload: Parameters<typeof updateRoom>[1] }) =>
+      updateRoom(targetRoomId, payload),
+    onSuccess: async (_, variables) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: roomQueries.lists() }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.detail(variables.targetRoomId).queryKey }),
+        queryClient.invalidateQueries({ queryKey: roomQueries.members(variables.targetRoomId).queryKey }),
+      ]);
+
+      onSuccess?.();
+      handleClose();
+    },
+    onError: (error) => {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        onRequireLogin?.();
+      }
+
+      const message = getRoomSubmitErrorMessage(error, 'edit');
+      setSubmitMessage(message);
+      setSubmitMessageTone('error');
+      onError?.(message);
     },
   });
 
@@ -175,17 +265,37 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
       }
 
       setSubmitMessage('');
+      const roomType: 'MALE' | 'FEMALE' | 'ANY' =
+        value.roomType === 'MIXED' ? 'ANY' : value.roomType;
 
-      await createRoomMutation.mutateAsync({
+      const payload = {
         title,
         description: description || undefined,
-        roomType: value.roomType === 'MIXED' ? 'ANY' : value.roomType,
+        roomType,
         maxMembersCount,
         place,
         lunchAt,
         minAge,
         maxAge,
-      });
+      };
+
+      if (isEditMode) {
+        if (!roomId) {
+          setSubmitMessage('수정할 방 정보를 찾을 수 없어요.');
+          setSubmitMessageTone('error');
+          onError?.('수정할 방 정보를 찾을 수 없어요.');
+          return;
+        }
+
+        await updateRoomMutation.mutateAsync({
+          targetRoomId: roomId,
+          payload,
+        });
+
+        return;
+      }
+
+      await createRoomMutation.mutateAsync(payload);
     },
   });
 
@@ -206,9 +316,20 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    createRoomForm.reset(initialValues ?? INITIAL_CREATE_ROOM_FORM_STATE);
+    setSubmitMessage('');
+    setSubmitMessageTone('success');
+  }, [createRoomForm, initialValues, isOpen]);
+
   const handleClose = () => {
-    createRoomForm.reset();
+    createRoomForm.reset(initialValues ?? INITIAL_CREATE_ROOM_FORM_STATE);
     createRoomMutation.reset();
+    updateRoomMutation.reset();
     setSubmitMessage('');
     setSubmitMessageTone('success');
     onClose();
@@ -230,9 +351,11 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
       <div className="p-6 md:p-7">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <p className="text-sm font-semibold text-indigo-500">점심 방 만들기</p>
+            <p className="text-sm font-semibold text-indigo-500">
+              {isEditMode ? '점심 방 수정하기' : '점심 방 만들기'}
+            </p>
             <h2 className="mt-1 text-[24px] font-bold tracking-[-0.03em] text-slate-900">
-              함께 점심할 친구를 모집해보세요
+              {isEditMode ? '현재 방 정보를 수정해보세요' : '함께 점심할 친구를 모집해보세요'}
             </h2>
           </div>
 
@@ -424,10 +547,16 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
             </button>
             <button
               type="submit"
-              disabled={createRoomMutation.isPending}
+              disabled={createRoomMutation.isPending || updateRoomMutation.isPending}
               className="rounded-2xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(99,102,241,0.28)] transition hover:bg-indigo-600 disabled:cursor-not-allowed disabled:bg-indigo-300"
             >
-              {createRoomMutation.isPending ? '방 만드는 중...' : '방 만들기'}
+              {createRoomMutation.isPending || updateRoomMutation.isPending
+                ? isEditMode
+                  ? '방 수정 중...'
+                  : '방 만드는 중...'
+                : isEditMode
+                  ? '방 수정하기'
+                  : '방 만들기'}
             </button>
           </div>
         </form>
@@ -437,3 +566,4 @@ const CreateRoomModal = ({ isOpen, onClose }: CreateRoomModalProps) => {
 };
 
 export default CreateRoomModal;
+export { toCreateRoomFormState };

--- a/src/shared/api/rooms/index.ts
+++ b/src/shared/api/rooms/index.ts
@@ -7,6 +7,7 @@ export type {
   RoomJoinResponse,
   RoomListItemResponse,
   RoomMemberResponse,
+  UpdateRoomRequest,
 } from './rooms';
 export {
   createRoom,
@@ -16,5 +17,6 @@ export {
   joinRoom,
   kickRoomMember,
   leaveRoom,
+  updateRoom,
 } from './rooms';
 export { roomQueries } from './roomsQueries';

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -49,6 +49,17 @@ export interface CreateRoomRequest {
   maxAge: number;
 }
 
+export interface UpdateRoomRequest {
+  title?: string;
+  description?: string;
+  roomType?: 'MALE' | 'FEMALE' | 'ANY';
+  maxMembersCount?: number;
+  place?: string;
+  lunchAt?: string;
+  minAge?: number;
+  maxAge?: number;
+}
+
 export interface RoomJoinResponse {
   roomId: number;
   userId: number;
@@ -96,6 +107,15 @@ export async function getRoomMembers(roomId: number): Promise<GetRoomMembersResp
 
 export async function createRoom(payload: CreateRoomRequest): Promise<RoomDetailResponse> {
   const response = await client.post<RoomDetailResponse>('/api/v1/rooms', payload);
+
+  return response.data;
+}
+
+export async function updateRoom(
+  roomId: number,
+  payload: UpdateRoomRequest,
+): Promise<RoomDetailResponse> {
+  const response = await client.patch<RoomDetailResponse>(`/api/v1/rooms/${roomId}`, payload);
 
   return response.data;
 }


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 상세에서 방장 전용 수정 액션을 실제 `PATCH /api/v1/rooms/{roomId}` 흐름에 맞춰 연결했습니다.
- `CreateRoomModal`을 생성/수정 공용 모달로 확장해, 기존 생성 폼을 재사용하면서 방 정보 수정까지 처리할 수 있도록 정리했습니다.
- 수정 성공 후 ROOM 목록, 상세, 멤버 목록을 다시 불러오고, 공용 메시지 영역에서 성공/실패 상태를 확인할 수 있도록 구성했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts`에 `UpdateRoomRequest`, `updateRoom(roomId, payload)` 추가
- `src/shared/api/rooms/index.ts` export 정리
- `src/pages/main/ui/room/CreateRoomModal.tsx`를 생성/수정 공용 모달로 확장
- `src/pages/main/ui/layout/MainTabSection.tsx`에 방장 전용 `방 수정` 버튼과 수정 모달 진입, 성공/실패 메시지 연결 추가
- `src/pages/main/ui/layout/MainPage.tsx`에서 생성 모달의 로그인 모달 연결 정리

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 ROOM 수정 액션 연결과 생성/수정 공용 모달 재사용 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 수정 범위는 기본 필드만 포함하고 `status` 변경은 이번 범위에서 제외했습니다.
- 방장만 수정 버튼을 볼 수 있고, 수정 확인 모달 없이 즉시 제출합니다.
- `401 / 403 / 404 / 409` 실패는 ROOM 공용 메시지 영역에서 처리합니다.
- 새로고침 후 참여 상태 복원과 삭제/닫기/강제 종료는 이번 범위에 포함하지 않았습니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #74
