### PR TITLE
feat: (#76) 게시글 목록 조회 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -1,9 +1,12 @@
-import { Heart, MessageSquareText, Pencil, SendHorizonal, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { Heart, MessageSquareText } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { postQueries, type PostListItemResponse } from '@/shared/api/posts';
 import { cn } from '@/shared/lib/utils';
+import type { MainBoardPost } from './types';
 
-import { mockBoardComments } from './mockBoardComments';
-import { mockBoardPosts } from './mockBoardPosts';
+const BOARD_LIST_DEFAULT_PAGE = 1;
+const BOARD_LIST_DEFAULT_SIZE = 10;
 
 const categoryStyleMap = {
   FREE: 'bg-slate-100 text-slate-600',
@@ -11,6 +14,13 @@ const categoryStyleMap = {
   INFO: 'bg-sky-50 text-sky-700',
   TALK: 'bg-violet-50 text-violet-700',
 } as const;
+
+const postCategoryIdLabelMap: Record<number, MainBoardPost['category']> = {
+  1: 'FREE',
+  2: 'REVIEW',
+  3: 'INFO',
+  4: 'TALK',
+};
 
 const formatRelativeCreatedAt = (createdAt: string) => {
   const currentTime = Date.now();
@@ -32,68 +42,159 @@ const formatRelativeCreatedAt = (createdAt: string) => {
   return `${diffDays}일 전`;
 };
 
+const toBoardCategory = (post: PostListItemResponse): MainBoardPost['category'] => {
+  if (
+    post.category === 'FREE' ||
+    post.category === 'REVIEW' ||
+    post.category === 'INFO' ||
+    post.category === 'TALK'
+  ) {
+    return post.category;
+  }
+
+  if (post.categoryId !== undefined && post.categoryId !== null) {
+    return postCategoryIdLabelMap[post.categoryId] ?? 'FREE';
+  }
+
+  return 'FREE';
+};
+
+const toBoardAuthor = (post: PostListItemResponse) =>
+  post.author?.trim() ||
+  post.authorNickname?.trim() ||
+  post.userNickname?.trim() ||
+  post.nickname?.trim() ||
+  post.user?.nickname?.trim() ||
+  post.user?.name?.trim() ||
+  '익명 사용자';
+
+const toBoardSummary = (post: PostListItemResponse) => {
+  const sourceText = post.summary?.trim() || post.content?.trim() || '';
+
+  if (sourceText === '') {
+    return '게시글 요약이 아직 없어요.';
+  }
+
+  if (sourceText.length <= 90) {
+    return sourceText;
+  }
+
+  return `${sourceText.slice(0, 90).trimEnd()}...`;
+};
+
+const toMainBoardPost = (post: PostListItemResponse): MainBoardPost => ({
+  id: post.id,
+  category: toBoardCategory(post),
+  title: post.title,
+  author: toBoardAuthor(post),
+  summary: toBoardSummary(post),
+  content: post.content ?? '',
+  likedCount: post.likeCount ?? 0,
+  commentCount: post.commentCount ?? 0,
+  createdAt: post.createdAt,
+});
+
 const MainBoardSection = () => {
-  const initialSelectedBoardPostId = mockBoardPosts[0]?.id ?? null;
-  const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(
-    initialSelectedBoardPostId,
+  const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(null);
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+  } = useQuery(
+    postQueries.list({
+      page: BOARD_LIST_DEFAULT_PAGE,
+      size: BOARD_LIST_DEFAULT_SIZE,
+    }),
   );
-  const selectedBoardPost = mockBoardPosts.find(
-    (mockBoardPost) => mockBoardPost.id === selectedBoardPostId,
-  );
-  const selectedBoardComments = mockBoardComments.filter(
-    (mockBoardComment) => mockBoardComment.postId === selectedBoardPostId,
-  );
+  const boardPosts = data?.items.map(toMainBoardPost) ?? [];
+  const selectedBoardPost = boardPosts.find((boardPost) => boardPost.id === selectedBoardPostId);
+
+  useEffect(() => {
+    if (boardPosts.length === 0) {
+      setSelectedBoardPostId(null);
+      return;
+    }
+
+    const hasSelectedBoardPost =
+      selectedBoardPostId !== null && boardPosts.some((boardPost) => boardPost.id === selectedBoardPostId);
+
+    if (!hasSelectedBoardPost) {
+      setSelectedBoardPostId(boardPosts[0].id);
+    }
+  }, [boardPosts, selectedBoardPostId]);
 
   return (
     <section className="space-y-4 md:space-y-5">
-      {mockBoardPosts.map((mockBoardPost) => (
-        <article
-          key={mockBoardPost.id}
-          className={cn(
-            'cursor-pointer rounded-[28px] border bg-white p-5 shadow-[0_12px_30px_rgba(15,23,42,0.05)] transition',
-            selectedBoardPostId === mockBoardPost.id
-              ? 'border-indigo-200 ring-4 ring-indigo-100/60'
-              : 'border-slate-200/80 hover:border-slate-300',
-          )}
-          onClick={() => setSelectedBoardPostId(mockBoardPost.id)}
-        >
-          <div className="flex items-center justify-between gap-3">
-            <span
+      {isLoading ? (
+        <section className="rounded-[28px] border border-slate-200/80 bg-white px-6 py-10 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+          게시글을 불러오는 중...
+        </section>
+      ) : null}
+
+      {isError ? (
+        <section className="rounded-[28px] border border-rose-200 bg-rose-50 px-6 py-10 text-center text-sm text-rose-600 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+          게시글을 불러오지 못했어요.
+          {error instanceof Error ? ` ${error.message}` : ''}
+        </section>
+      ) : null}
+
+      {!isLoading && !isError && boardPosts.length === 0 ? (
+        <section className="rounded-[28px] border border-slate-200/80 bg-white px-6 py-10 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+          아직 등록된 게시글이 없어요.
+        </section>
+      ) : null}
+
+      {!isLoading && !isError
+        ? boardPosts.map((boardPost) => (
+            <article
+              key={boardPost.id}
               className={cn(
-                'inline-flex rounded-full px-3 py-1 text-xs font-semibold',
-                categoryStyleMap[mockBoardPost.category],
+                'cursor-pointer rounded-[28px] border bg-white p-5 shadow-[0_12px_30px_rgba(15,23,42,0.05)] transition',
+                selectedBoardPostId === boardPost.id
+                  ? 'border-indigo-200 ring-4 ring-indigo-100/60'
+                  : 'border-slate-200/80 hover:border-slate-300',
               )}
+              onClick={() => setSelectedBoardPostId(boardPost.id)}
             >
-              {mockBoardPost.category}
-            </span>
-            <span className="text-sm text-slate-400">
-              {formatRelativeCreatedAt(mockBoardPost.createdAt)}
-            </span>
-          </div>
+              <div className="flex items-center justify-between gap-3">
+                <span
+                  className={cn(
+                    'inline-flex rounded-full px-3 py-1 text-xs font-semibold',
+                    categoryStyleMap[boardPost.category],
+                  )}
+                >
+                  {boardPost.category}
+                </span>
+                <span className="text-sm text-slate-400">
+                  {formatRelativeCreatedAt(boardPost.createdAt)}
+                </span>
+              </div>
 
-          <h2 className="mt-4 text-[19px] font-bold tracking-[-0.03em] text-slate-900">
-            {mockBoardPost.title}
-          </h2>
-          <p className="mt-2 text-sm leading-6 text-slate-500">{mockBoardPost.summary}</p>
+              <h2 className="mt-4 text-[19px] font-bold tracking-[-0.03em] text-slate-900">
+                {boardPost.title}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-500">{boardPost.summary}</p>
 
-          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
-            <span className="font-medium text-slate-700">{mockBoardPost.author}</span>
+              <div className="mt-5 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
+                <span className="font-medium text-slate-700">{boardPost.author}</span>
 
-            <div className="flex items-center gap-4">
-              <span className="inline-flex items-center gap-1.5">
-                <Heart className="h-4 w-4 text-rose-400" />
-                {mockBoardPost.likedCount}
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <MessageSquareText className="h-4 w-4 text-indigo-500" />
-                {mockBoardPost.commentCount}
-              </span>
-            </div>
-          </div>
-        </article>
-      ))}
+                <div className="flex items-center gap-4">
+                  <span className="inline-flex items-center gap-1.5">
+                    <Heart className="h-4 w-4 text-rose-400" />
+                    {boardPost.likedCount}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <MessageSquareText className="h-4 w-4 text-indigo-500" />
+                    {boardPost.commentCount}
+                  </span>
+                </div>
+              </div>
+            </article>
+          ))
+        : null}
 
-      {selectedBoardPost ? (
+      {selectedBoardPost && !isLoading && !isError ? (
         <article className="rounded-[32px] border border-slate-200/80 bg-white p-6 shadow-[0_16px_40px_rgba(15,23,42,0.06)] md:p-7">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-3">
@@ -121,88 +222,9 @@ const MainBoardSection = () => {
           </h3>
           <p className="mt-2 text-sm font-medium text-slate-500">{selectedBoardPost.author}</p>
 
-          <div className="mt-6 whitespace-pre-line rounded-[24px] bg-slate-50 px-5 py-5 text-sm leading-7 text-slate-600">
-            {selectedBoardPost.content}
+          <div className="mt-6 rounded-[24px] bg-slate-50 px-5 py-5 text-sm leading-7 text-slate-600">
+            게시글 상세와 댓글은 다음 이슈에서 연결 예정이에요.
           </div>
-
-          <section className="mt-8">
-            <div className="flex items-center justify-between gap-3">
-              <h4 className="text-lg font-bold tracking-[-0.03em] text-slate-900">
-                댓글 {selectedBoardComments.length}
-              </h4>
-              <span className="text-sm text-slate-400">mock UI</span>
-            </div>
-
-            <div className="mt-4 rounded-[24px] border border-slate-200 bg-slate-50 p-4">
-              <label className="block">
-                <span className="text-sm font-semibold text-slate-700">댓글 작성</span>
-                <textarea
-                  placeholder="댓글을 입력해보세요"
-                  className="mt-3 min-h-[110px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
-                />
-              </label>
-
-              <div className="mt-4 flex justify-end">
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-2 rounded-2xl bg-indigo-500 px-4 py-3 text-sm font-semibold text-white transition hover:bg-indigo-600"
-                >
-                  <SendHorizonal className="h-4 w-4" />
-                  댓글 등록
-                </button>
-              </div>
-            </div>
-
-            <div className="mt-5 space-y-3">
-              {selectedBoardComments.map((selectedBoardComment) => (
-                <article
-                  key={selectedBoardComment.id}
-                  className="rounded-[24px] border border-slate-200/80 bg-white px-5 py-4"
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <div className="text-sm font-semibold text-slate-900">
-                        {selectedBoardComment.author}
-                      </div>
-                      <div className="mt-1 text-xs text-slate-400">
-                        {formatRelativeCreatedAt(selectedBoardComment.createdAt)}
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-3 text-xs font-medium text-slate-400">
-                      <span className="inline-flex items-center gap-1">
-                        <Heart className="h-3.5 w-3.5 text-rose-400" />
-                        {selectedBoardComment.likedCount}
-                      </span>
-
-                      {selectedBoardComment.isMine ? (
-                        <>
-                          <button
-                            type="button"
-                            className="inline-flex items-center gap-1 hover:text-slate-600"
-                          >
-                            <Pencil className="h-3.5 w-3.5" />
-                            수정
-                          </button>
-                          <button
-                            type="button"
-                            className="inline-flex items-center gap-1 hover:text-slate-600"
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                            삭제
-                          </button>
-                        </>
-                      ) : null}
-                    </div>
-                  </div>
-
-                  <p className="mt-3 text-sm leading-6 text-slate-600">
-                    {selectedBoardComment.content}
-                  </p>
-                </article>
-              ))}
-            </div>
-          </section>
         </article>
       ) : null}
     </section>

--- a/src/shared/api/posts/index.ts
+++ b/src/shared/api/posts/index.ts
@@ -1,0 +1,9 @@
+export type {
+  GetPostsParams,
+  GetPostsResponse,
+  PostListItemResponse,
+  PostListPaginationResponse,
+  PostListUserResponse,
+} from './posts';
+export { getPosts } from './posts';
+export { postQueries } from './postsQueries';

--- a/src/shared/api/posts/posts.ts
+++ b/src/shared/api/posts/posts.ts
@@ -1,0 +1,55 @@
+import client from '@/shared/api/client';
+
+export interface GetPostsParams {
+  categoryId?: number;
+  page?: number;
+  size?: number;
+}
+
+export interface PostListUserResponse {
+  id?: number;
+  nickname?: string;
+  name?: string;
+}
+
+export interface PostListItemResponse {
+  id: number;
+  categoryId?: number | null;
+  category?: string | null;
+  title: string;
+  summary?: string | null;
+  content?: string | null;
+  likeCount?: number | null;
+  commentCount?: number | null;
+  createdAt: string;
+  author?: string | null;
+  authorNickname?: string | null;
+  userNickname?: string | null;
+  nickname?: string | null;
+  user?: PostListUserResponse | null;
+}
+
+export interface PostListPaginationResponse {
+  page?: number;
+  size?: number;
+  totalCount?: number;
+  totalPages?: number;
+  hasNext?: boolean;
+}
+
+export interface GetPostsResponse {
+  items: PostListItemResponse[];
+  pagination?: PostListPaginationResponse;
+}
+
+export async function getPosts(params: GetPostsParams = {}): Promise<GetPostsResponse> {
+  const response = await client.get<GetPostsResponse>('/api/v1/posts', {
+    params: {
+      categoryId: params.categoryId,
+      page: params.page,
+      size: params.size,
+    },
+  });
+
+  return response.data;
+}

--- a/src/shared/api/posts/postsQueries.ts
+++ b/src/shared/api/posts/postsQueries.ts
@@ -1,0 +1,12 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getPosts, type GetPostsParams } from '@/shared/api/posts/posts';
+
+export const postQueries = {
+  all: () => ['posts'] as const,
+  lists: () => [...postQueries.all(), 'list'] as const,
+  list: (params: GetPostsParams = {}) =>
+    queryOptions({
+      queryKey: [...postQueries.lists(), params],
+      queryFn: () => getPosts(params),
+    }),
+};


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 탭의 게시글 목록을 `GET /api/v1/posts` 기반으로 전환했습니다.
- `shared/api/posts`와 `postQueries`를 추가해 게시글 목록 조회 구조를 만들고, BOARD 목록 렌더가 실제 응답을 기준으로 동작하도록 정리했습니다.
- 상세/댓글 영역은 이번 범위에서 실제 연동 대신 후속 이슈 안내 블록으로 전환했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/posts/posts.ts`에 `getPosts(params)`와 목록 응답 타입 추가
- `src/shared/api/posts/postsQueries.ts`, `src/shared/api/posts/index.ts` 추가
- `src/pages/main/ui/board/MainBoardSection.tsx`에서 mock 목록 제거, loading/error/empty/success 상태 추가, 실데이터 매핑 기반 렌더로 전환

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 목록 실데이터 전환과 상세/댓글 안내 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 기본 목록 쿼리는 `page=1`, `size=10` 기준으로 연결했습니다.
- 카테고리 필터, 페이지네이션, 상세, 댓글은 후속 이슈에서 다룹니다.
- `corepack pnpm build`를 실행했지만, 이번 변경이 아닌 기존 프로필 타입 불일치(`bio` / `introduce`) 때문에 전체 빌드는 실패했습니다.

## 🧐 이슈 (Related Issues)

- Closes #76
