### PR TITLE
refactor: (#105) Profile introduce 필드명 정합성 통일

### DIFF
--- a/src/pages/profile/ui/ProfilePage.tsx
+++ b/src/pages/profile/ui/ProfilePage.tsx
@@ -8,7 +8,7 @@ import { MBTI_OPTIONS, type MbtiType, type UserProfile } from '@/shared/types/pr
 const EMPTY_PROFILE: UserProfile = {
   name: '',
   nickname: '',
-  bio: '',
+  introduce: '',
   mbti: '',
   profileImageUrl: '',
 };
@@ -19,7 +19,7 @@ const isMbtiType = (value: unknown): value is MbtiType =>
 const normalizeProfile = (profile: Partial<UserProfile> | null | undefined): UserProfile => ({
   name: typeof profile?.name === 'string' ? profile.name : '',
   nickname: typeof profile?.nickname === 'string' ? profile.nickname : '',
-  bio: typeof profile?.bio === 'string' ? profile.bio : '',
+  introduce: typeof profile?.introduce === 'string' ? profile.introduce : '',
   mbti: isMbtiType(profile?.mbti) ? profile.mbti : '',
   profileImageUrl: typeof profile?.profileImageUrl === 'string' ? profile.profileImageUrl : '',
 });
@@ -103,7 +103,7 @@ export default function ProfilePage() {
     updateProfileMutation.mutate({
       name: profile.name.trim(),
       nickname: profile.nickname.trim(),
-      bio: profile.bio.trim(),
+      introduce: profile.introduce.trim(),
       mbti: profile.mbti as MbtiType,
       profileImageUrl: profile.profileImageUrl.trim(),
     });
@@ -226,7 +226,7 @@ export default function ProfilePage() {
                   </span>
                 </div>
               </div>
-              <p className="mt-2 text-lg text-slate-400">{profile.bio}</p>
+              <p className="mt-2 text-lg text-slate-400">{profile.introduce}</p>
             </div>
           </div>
 
@@ -251,12 +251,12 @@ export default function ProfilePage() {
             <label className="block">
               <span className="mb-3 block text-[18px] font-medium text-slate-800">한줄소개</span>
               <textarea
-                value={profile.bio}
+                value={profile.introduce}
                 onChange={(event) =>
                   setProfileDraft((current) => ({
                     ...profile,
                     ...current,
-                    bio: event.target.value,
+                    introduce: event.target.value,
                   }))
                 }
                 placeholder="소개를 입력하세요"


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- Profile 화면에서 남아 있던 `bio` 사용부를 타입 기준인 `introduce`로 통일했습니다.
- API/타입 계층은 유지하고, Profile UI 사용부만 정리해 필드명 정합성을 맞췄습니다.
- 이 리팩터링으로 기존 프로필 타입 불일치로 막히던 빌드 blocker를 해소했습니다.

## ✨ 변경 사항 (Changes)

- `src/pages/profile/ui/ProfilePage.tsx`에서 상태 초기값, normalize 로직, 저장 payload, 소개 문구 표시, textarea 바인딩의 `bio`를 `introduce`로 변경

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 Profile 필드명 정합성 정리와 빌드 정상화 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- `shared/types/profile.ts`, `shared/types/user.ts`, `shared/api/users/profile.ts`는 이미 `introduce` 기준이라 변경하지 않았습니다.
- 이번 작업은 동작 변경이 아니라 Profile UI 사용부 정리입니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #105
