### PR TITLE
feat: (#77) 게시글 카테고리 필터 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -4,23 +4,16 @@ import { useQuery } from '@tanstack/react-query';
 import { postQueries, type PostListItemResponse } from '@/shared/api/posts';
 import { cn } from '@/shared/lib/utils';
 import type { MainBoardPost } from './types';
+import {
+  boardCategoryFilterOptions,
+  boardCategoryIdLabelMap,
+  boardCategoryIdMap,
+  boardCategoryStyleMap,
+  type MainBoardCategoryFilter,
+} from './board.constants';
 
 const BOARD_LIST_DEFAULT_PAGE = 1;
 const BOARD_LIST_DEFAULT_SIZE = 10;
-
-const categoryStyleMap = {
-  FREE: 'bg-slate-100 text-slate-600',
-  REVIEW: 'bg-amber-50 text-amber-700',
-  INFO: 'bg-sky-50 text-sky-700',
-  TALK: 'bg-violet-50 text-violet-700',
-} as const;
-
-const postCategoryIdLabelMap: Record<number, MainBoardPost['category']> = {
-  1: 'FREE',
-  2: 'REVIEW',
-  3: 'INFO',
-  4: 'TALK',
-};
 
 const formatRelativeCreatedAt = (createdAt: string) => {
   const currentTime = Date.now();
@@ -53,7 +46,7 @@ const toBoardCategory = (post: PostListItemResponse): MainBoardPost['category'] 
   }
 
   if (post.categoryId !== undefined && post.categoryId !== null) {
-    return postCategoryIdLabelMap[post.categoryId] ?? 'FREE';
+    return boardCategoryIdLabelMap[post.categoryId] ?? 'FREE';
   }
 
   return 'FREE';
@@ -96,6 +89,9 @@ const toMainBoardPost = (post: PostListItemResponse): MainBoardPost => ({
 
 const MainBoardSection = () => {
   const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<MainBoardCategoryFilter>('ALL');
+  const categoryId =
+    selectedCategory === 'ALL' ? undefined : boardCategoryIdMap[selectedCategory];
   const {
     data,
     isLoading,
@@ -105,6 +101,7 @@ const MainBoardSection = () => {
     postQueries.list({
       page: BOARD_LIST_DEFAULT_PAGE,
       size: BOARD_LIST_DEFAULT_SIZE,
+      categoryId,
     }),
   );
   const boardPosts = data?.items.map(toMainBoardPost) ?? [];
@@ -126,6 +123,29 @@ const MainBoardSection = () => {
 
   return (
     <section className="space-y-4 md:space-y-5">
+      <section className="rounded-[28px] border border-slate-200/80 bg-white px-5 py-5 shadow-[0_12px_30px_rgba(15,23,42,0.05)] md:px-6">
+        <div>
+          <p className="text-sm font-semibold text-slate-700">카테고리</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {boardCategoryFilterOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setSelectedCategory(option.value)}
+                className={cn(
+                  'rounded-2xl px-4 py-2.5 text-sm font-semibold transition',
+                  selectedCategory === option.value
+                    ? 'bg-slate-900 text-white'
+                    : 'border border-slate-200 bg-white text-slate-600 hover:bg-slate-50',
+                )}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+
       {isLoading ? (
         <section className="rounded-[28px] border border-slate-200/80 bg-white px-6 py-10 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
           게시글을 불러오는 중...
@@ -161,7 +181,7 @@ const MainBoardSection = () => {
                 <span
                   className={cn(
                     'inline-flex rounded-full px-3 py-1 text-xs font-semibold',
-                    categoryStyleMap[boardPost.category],
+                    boardCategoryStyleMap[boardPost.category],
                   )}
                 >
                   {boardPost.category}
@@ -201,7 +221,7 @@ const MainBoardSection = () => {
               <span
                 className={cn(
                   'inline-flex rounded-full px-3 py-1 text-xs font-semibold',
-                  categoryStyleMap[selectedBoardPost.category],
+                  boardCategoryStyleMap[selectedBoardPost.category],
                 )}
               >
                 {selectedBoardPost.category}

--- a/src/pages/main/ui/board/board.constants.ts
+++ b/src/pages/main/ui/board/board.constants.ts
@@ -1,0 +1,36 @@
+import type { MainBoardPost } from './types';
+
+export type MainBoardCategory = MainBoardPost['category'];
+export type MainBoardCategoryFilter = 'ALL' | MainBoardCategory;
+
+export const boardCategoryStyleMap: Record<MainBoardCategory, string> = {
+  FREE: 'bg-slate-100 text-slate-600',
+  REVIEW: 'bg-amber-50 text-amber-700',
+  INFO: 'bg-sky-50 text-sky-700',
+  TALK: 'bg-violet-50 text-violet-700',
+};
+
+export const boardCategoryIdMap: Record<MainBoardCategory, number> = {
+  FREE: 1,
+  REVIEW: 2,
+  INFO: 3,
+  TALK: 4,
+};
+
+export const boardCategoryIdLabelMap: Record<number, MainBoardCategory> = {
+  1: 'FREE',
+  2: 'REVIEW',
+  3: 'INFO',
+  4: 'TALK',
+};
+
+export const boardCategoryFilterOptions: Array<{
+  value: MainBoardCategoryFilter;
+  label: string;
+}> = [
+  { value: 'ALL', label: '전체' },
+  { value: 'FREE', label: '자유' },
+  { value: 'REVIEW', label: '리뷰' },
+  { value: 'INFO', label: '정보' },
+  { value: 'TALK', label: '잡담' },
+];


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 탭에 카테고리 필터를 추가하고 `GET /api/v1/posts`의 `categoryId` 파라미터와 연결했습니다.
- 필터 변경 시 React Query query key가 바뀌면서 게시글 목록이 자동으로 재조회되도록 구성했습니다.
- 카테고리 정의를 `board.constants.ts`로 분리해, 필터 버튼과 카드 배지가 같은 기준을 사용하도록 정리했습니다.

## ✨ 변경 사항 (Changes)

- `src/pages/main/ui/board/board.constants.ts` 추가
- `src/pages/main/ui/board/MainBoardSection.tsx`에 `전체 / 자유 / 리뷰 / 정보 / 잡담` 버튼형 필터, `categoryId` 매핑, 필터 변경 시 목록/선택 상태 정리 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 카테고리 필터 연결과 카테고리 상수 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 초기값은 `전체`이며, `FREE=1`, `REVIEW=2`, `INFO=3`, `TALK=4` 매핑을 사용합니다.
- 페이지네이션은 아직 `page=1`, `size=10` 고정이며 후속 이슈에서 다룹니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #77
