### PR TITLE
feat: (#78) 게시글 스크롤 / 페이지네이션 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -1,6 +1,6 @@
 import { Heart, MessageSquareText } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { postQueries, type PostListItemResponse } from '@/shared/api/posts';
 import { cn } from '@/shared/lib/utils';
 import type { MainBoardPost } from './types';
@@ -90,6 +90,7 @@ const toMainBoardPost = (post: PostListItemResponse): MainBoardPost => ({
 const MainBoardSection = () => {
   const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<MainBoardCategoryFilter>('ALL');
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const categoryId =
     selectedCategory === 'ALL' ? undefined : boardCategoryIdMap[selectedCategory];
   const {
@@ -97,15 +98,23 @@ const MainBoardSection = () => {
     isLoading,
     isError,
     error,
-  } = useQuery(
-    postQueries.list({
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+  } = useInfiniteQuery(
+    postQueries.infiniteList({
       page: BOARD_LIST_DEFAULT_PAGE,
       size: BOARD_LIST_DEFAULT_SIZE,
       categoryId,
     }),
   );
-  const boardPosts = data?.items.map(toMainBoardPost) ?? [];
+  const boardPosts = useMemo(
+    () => data?.pages.flatMap((page) => page.items).map(toMainBoardPost) ?? [],
+    [data],
+  );
   const selectedBoardPost = boardPosts.find((boardPost) => boardPost.id === selectedBoardPostId);
+  const hasLoadedPosts = data !== undefined;
 
   useEffect(() => {
     if (boardPosts.length === 0) {
@@ -120,6 +129,30 @@ const MainBoardSection = () => {
       setSelectedBoardPostId(boardPosts[0].id);
     }
   }, [boardPosts, selectedBoardPostId]);
+
+  useEffect(() => {
+    const target = loadMoreRef.current;
+
+    if (!target || isLoading || isError || !hasNextPage) {
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+
+      if (!entry?.isIntersecting || isFetchingNextPage || !hasNextPage) {
+        return;
+      }
+
+      void fetchNextPage();
+    });
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [fetchNextPage, hasNextPage, isError, isFetchingNextPage, isLoading]);
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -213,6 +246,30 @@ const MainBoardSection = () => {
             </article>
           ))
         : null}
+
+      {!isLoading && !isError && boardPosts.length > 0 ? (
+        <div className="space-y-3">
+          {isFetchingNextPage ? (
+            <section className="rounded-[24px] border border-slate-200/80 bg-white px-5 py-4 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+              게시글을 더 불러오는 중...
+            </section>
+          ) : null}
+
+          {!hasNextPage && hasLoadedPosts ? (
+            <section className="rounded-[24px] border border-slate-200/80 bg-white px-5 py-4 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+              마지막 게시글까지 모두 확인했어요.
+            </section>
+          ) : null}
+
+          {isFetchNextPageError ? (
+            <section className="rounded-[24px] border border-rose-200 bg-rose-50 px-5 py-4 text-center text-sm text-rose-600 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+              게시글을 더 불러오지 못했어요.
+            </section>
+          ) : null}
+
+          <div ref={loadMoreRef} className="h-1 w-full" aria-hidden="true" />
+        </div>
+      ) : null}
 
       {selectedBoardPost && !isLoading && !isError ? (
         <article className="rounded-[32px] border border-slate-200/80 bg-white p-6 shadow-[0_16px_40px_rgba(15,23,42,0.06)] md:p-7">

--- a/src/shared/api/posts/postsQueries.ts
+++ b/src/shared/api/posts/postsQueries.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
 import { getPosts, type GetPostsParams } from '@/shared/api/posts/posts';
 
 export const postQueries = {
@@ -8,5 +8,30 @@ export const postQueries = {
     queryOptions({
       queryKey: [...postQueries.lists(), params],
       queryFn: () => getPosts(params),
+    }),
+  infiniteList: ({ page, ...params }: GetPostsParams = {}) =>
+    infiniteQueryOptions({
+      queryKey: [...postQueries.lists(), 'infinite', params],
+      initialPageParam: 1,
+      queryFn: ({ pageParam }) =>
+        getPosts({
+          ...params,
+          page: pageParam,
+        }),
+      getNextPageParam: (lastPage) => {
+        const currentPage = lastPage.pagination?.page ?? 1;
+        const totalPages = lastPage.pagination?.totalPages;
+        const hasNext = lastPage.pagination?.hasNext;
+
+        if (hasNext === true) {
+          return currentPage + 1;
+        }
+
+        if (typeof totalPages === 'number' && currentPage < totalPages) {
+          return currentPage + 1;
+        }
+
+        return undefined;
+      },
     }),
 };


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 탭의 게시글 목록을 `page / size` 기반 단건 조회에서 `useInfiniteQuery` 기반 누적 목록으로 전환했습니다.
- 목록 하단 sentinel을 `IntersectionObserver`로 감지해 자동으로 다음 페이지를 불러오도록 연결했습니다.
- 첫 페이지 상태와 별도로 추가 로딩 중, 마지막 목록, 추가 로딩 실패 상태를 하단 UI로 분리했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/posts/postsQueries.ts`에 `postQueries.infiniteList(...)` 추가
- `src/pages/main/ui/board/MainBoardSection.tsx`에서 `useInfiniteQuery` 전환, 누적 목록 평탄화, sentinel 기반 자동 로딩, 추가 로딩 상태 UI 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 무한 스크롤 연결과 추가 로딩 상태 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 기본 요청은 `page=1`, `size=10` 기준으로 시작합니다.
- 다음 페이지 판단은 `pagination.hasNext` 우선, 없으면 `page < totalPages` fallback을 사용합니다.
- 카테고리 필터와 함께 써도 필터별로 첫 페이지부터 다시 시작합니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #78
