### PR TITLE
feat: (#109) 방 목록 스크롤 / 페이지네이션 연결

### DIFF
--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { type InfiniteData, useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { Clock3, MapPin, Plus, Users } from 'lucide-react';
 import { isAuthenticated } from '@/app/authSessionStore';
@@ -40,6 +40,8 @@ interface MainTabSectionProps {
 interface ApiErrorPayload {
   message?: string | string[];
 }
+
+const ROOM_LIST_DEFAULT_SIZE = 10;
 
 const tabDescriptionMap: Record<MainTab, string> = {
   ROOM: '현재 열려 있는 점심 방을 둘러보고, 바로 참여할 수 있어요.',
@@ -162,6 +164,20 @@ const getDeleteRoomErrorMessage = (error: unknown) => {
   return '방 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.';
 };
 
+const isRoomsResponse = (data: unknown): data is GetRoomsResponse =>
+  typeof data === 'object' &&
+  data !== null &&
+  'items' in data &&
+  Array.isArray((data as GetRoomsResponse).items);
+
+const isInfiniteRoomsData = (
+  data: unknown,
+): data is InfiniteData<GetRoomsResponse, string | undefined> =>
+  typeof data === 'object' &&
+  data !== null &&
+  'pages' in data &&
+  Array.isArray((data as InfiniteData<GetRoomsResponse, string | undefined>).pages);
+
 const MainTabSection = ({
   activeTab,
   onCreateRoomClick,
@@ -178,10 +194,20 @@ const MainTabSection = ({
   const [roomActionMessageTone, setRoomActionMessageTone] = useState<'success' | 'error'>(
     'success',
   );
+  const roomListLoadMoreRef = useRef<HTMLDivElement | null>(null);
   const roomFilters = toRoomListFilters(roomFilterState);
   const isLoggedIn = isAuthenticated();
-  const { data, isLoading, isError, error } = useQuery({
-    ...roomQueries.list(roomFilters),
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+  } = useInfiniteQuery({
+    ...roomQueries.infiniteList(roomFilters, ROOM_LIST_DEFAULT_SIZE),
     enabled: isRoomTab,
   });
   const { data: currentUser } = useQuery({
@@ -289,14 +315,26 @@ const MainTabSection = ({
       setIsEditRoomModalOpen(false);
       setJoinedRoomId((currentRoomId) => (currentRoomId === roomId ? null : currentRoomId));
       setSelectedRoomId((currentRoomId) => (currentRoomId === roomId ? null : currentRoomId));
-      queryClient.setQueriesData<GetRoomsResponse>({ queryKey: roomQueries.lists() }, (oldData) =>
-        oldData
-          ? {
-              ...oldData,
-              items: oldData.items.filter((room) => room.id !== roomId),
-            }
-          : oldData,
-      );
+      queryClient.setQueriesData({ queryKey: roomQueries.lists() }, (oldData: unknown) => {
+        if (isRoomsResponse(oldData)) {
+          return {
+            ...oldData,
+            items: oldData.items.filter((room) => room.id !== roomId),
+          };
+        }
+
+        if (isInfiniteRoomsData(oldData)) {
+          return {
+            ...oldData,
+            pages: oldData.pages.map((page) => ({
+              ...page,
+              items: page.items.filter((room) => room.id !== roomId),
+            })),
+          };
+        }
+
+        return oldData;
+      });
       queryClient.removeQueries({ queryKey: roomQueries.detail(roomId).queryKey });
       queryClient.removeQueries({ queryKey: roomQueries.members(roomId).queryKey });
 
@@ -318,7 +356,10 @@ const MainTabSection = ({
       setRoomActionMessageTone('error');
     },
   });
-  const rooms = data?.items.map(toMainRoom) ?? [];
+  const rooms = useMemo(
+    () => data?.pages.flatMap((page) => page.items).map(toMainRoom) ?? [],
+    [data],
+  );
 
   useEffect(() => {
     if (!isRoomTab) {
@@ -337,6 +378,30 @@ const MainTabSection = ({
       setSelectedRoomId(rooms[0].id);
     }
   }, [isRoomTab, rooms, selectedRoomId]);
+
+  useEffect(() => {
+    const target = roomListLoadMoreRef.current;
+
+    if (!isRoomTab || !target || isLoading || isError || !hasNextPage) {
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+
+      if (!entry?.isIntersecting || isFetchingNextPage || !hasNextPage) {
+        return;
+      }
+
+      void fetchNextPage();
+    });
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [fetchNextPage, hasNextPage, isError, isFetchingNextPage, isLoading, isRoomTab]);
 
   const handleJoinClick = (roomId: number) => {
     if (!isAuthenticated()) {
@@ -559,6 +624,30 @@ const MainTabSection = ({
                 );
               })
             : null}
+
+          {!isLoading && !isError && rooms.length > 0 ? (
+            <div className="space-y-3">
+              {isFetchingNextPage ? (
+                <section className="rounded-[24px] border border-slate-200/80 bg-white px-5 py-4 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+                  점심 방을 더 불러오는 중...
+                </section>
+              ) : null}
+
+              {!hasNextPage ? (
+                <section className="rounded-[24px] border border-slate-200/80 bg-white px-5 py-4 text-center text-sm text-slate-500 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+                  마지막 방까지 모두 확인했어요.
+                </section>
+              ) : null}
+
+              {isFetchNextPageError ? (
+                <section className="rounded-[24px] border border-rose-200 bg-rose-50 px-5 py-4 text-center text-sm text-rose-600 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+                  점심 방을 더 불러오지 못했어요.
+                </section>
+              ) : null}
+
+              <div ref={roomListLoadMoreRef} className="h-1 w-full" aria-hidden="true" />
+            </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/src/shared/api/rooms/rooms.ts
+++ b/src/shared/api/rooms/rooms.ts
@@ -14,6 +14,7 @@ export interface RoomListItemResponse {
 
 export interface GetRoomsResponse {
   items: RoomListItemResponse[];
+  nextCursor?: string | null;
 }
 
 export interface RoomListFilters {
@@ -21,6 +22,11 @@ export interface RoomListFilters {
   status?: 'OPEN' | 'FULL' | 'CLOSE';
   minAge?: number;
   maxAge?: number;
+}
+
+export interface GetRoomsParams extends RoomListFilters {
+  cursor?: string;
+  size?: number;
 }
 
 export interface RoomDetailResponse {
@@ -80,13 +86,15 @@ export interface KickRoomMemberRequest {
   userId: number;
 }
 
-export async function getRooms(filters: RoomListFilters = {}): Promise<GetRoomsResponse> {
+export async function getRooms(params: GetRoomsParams = {}): Promise<GetRoomsResponse> {
   const response = await client.get<GetRoomsResponse>('/api/v1/rooms', {
     params: {
-      roomType: filters.roomType,
-      status: filters.status,
-      minAge: filters.minAge,
-      maxAge: filters.maxAge,
+      roomType: params.roomType,
+      status: params.status,
+      minAge: params.minAge,
+      maxAge: params.maxAge,
+      cursor: params.cursor,
+      size: params.size,
     },
   });
 

--- a/src/shared/api/rooms/roomsQueries.ts
+++ b/src/shared/api/rooms/roomsQueries.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
 import { getRoomDetail, getRoomMembers, getRooms, type RoomListFilters } from '@/shared/api/rooms/rooms';
 
 export const roomQueries = {
@@ -8,6 +8,18 @@ export const roomQueries = {
     queryOptions({
       queryKey: [...roomQueries.lists(), filters],
       queryFn: () => getRooms(filters),
+    }),
+  infiniteList: (filters: RoomListFilters = {}, size = 10) =>
+    infiniteQueryOptions({
+      queryKey: [...roomQueries.lists(), 'infinite', filters, size],
+      initialPageParam: undefined as string | undefined,
+      queryFn: ({ pageParam }) =>
+        getRooms({
+          ...filters,
+          cursor: pageParam,
+          size,
+        }),
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     }),
   details: () => [...roomQueries.all(), 'detail'] as const,
   detail: (roomId: number) =>


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- ROOM 탭의 방 목록을 단건 조회에서 `cursor` 기반 누적 목록으로 전환했습니다.
- 목록 하단 sentinel을 `IntersectionObserver`로 감지해 자동으로 다음 페이지를 불러오도록 연결했습니다.
- 첫 페이지 상태와 별도로 추가 로딩 중, 마지막 목록, 추가 조회 실패 상태를 하단 UI로 분리했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/rooms/rooms.ts`에 `cursor`, `size`, `nextCursor` 관련 타입/요청 파라미터 확장
- `src/shared/api/rooms/roomsQueries.ts`에 `roomQueries.infiniteList(...)` 추가
- `src/pages/main/ui/layout/MainTabSection.tsx`에서 `useInfiniteQuery` 전환, 누적 목록 평탄화, sentinel 기반 자동 로딩, 하단 추가 조회 상태 UI, infinite 목록 캐시 정리 대응 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 ROOM 목록 무한 스크롤 연결과 추가 조회 상태 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 기본 추가 조회는 `cursor`와 `size=10` 기준으로 동작합니다.
- 다음 페이지 판단은 `nextCursor` 존재 여부 기준입니다.
- 필터와 함께 써도 필터별로 첫 페이지부터 다시 시작합니다.
- 기존 join / leave / update / delete 이후에도 ROOM 목록 invalidate가 동작하도록 infinite 목록 캐시 정리를 함께 반영했습니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #109
