### PR TITLE
feat: (#79) 게시글 상세 조회 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -1,7 +1,11 @@
 import { Heart, MessageSquareText } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { postQueries, type PostListItemResponse } from '@/shared/api/posts';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  postQueries,
+  type PostDetailResponse,
+  type PostListItemResponse,
+} from '@/shared/api/posts';
 import { cn } from '@/shared/lib/utils';
 import type { MainBoardPost } from './types';
 import {
@@ -87,6 +91,21 @@ const toMainBoardPost = (post: PostListItemResponse): MainBoardPost => ({
   createdAt: post.createdAt,
 });
 
+const toMainBoardPostDetail = (
+  post: PostDetailResponse,
+  author: string,
+): MainBoardPost => ({
+  id: post.id,
+  category: toBoardCategory(post),
+  title: post.title,
+  author,
+  summary: post.content,
+  content: post.content,
+  likedCount: post.likeCount ?? 0,
+  commentCount: post.commentCount ?? 0,
+  createdAt: post.createdAt,
+});
+
 const MainBoardSection = () => {
   const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<MainBoardCategoryFilter>('ALL');
@@ -114,6 +133,19 @@ const MainBoardSection = () => {
     [data],
   );
   const selectedBoardPost = boardPosts.find((boardPost) => boardPost.id === selectedBoardPostId);
+  const {
+    data: selectedBoardPostDetailData,
+    isLoading: isBoardDetailLoading,
+    isError: isBoardDetailError,
+    error: boardDetailError,
+  } = useQuery({
+    ...postQueries.detail(selectedBoardPostId ?? 0),
+    enabled: selectedBoardPostId !== null,
+  });
+  const selectedBoardPostDetail =
+    selectedBoardPostDetailData && selectedBoardPost
+      ? toMainBoardPostDetail(selectedBoardPostDetailData, selectedBoardPost.author)
+      : null;
   const hasLoadedPosts = data !== undefined;
 
   useEffect(() => {
@@ -273,35 +305,68 @@ const MainBoardSection = () => {
 
       {selectedBoardPost && !isLoading && !isError ? (
         <article className="rounded-[32px] border border-slate-200/80 bg-white p-6 shadow-[0_16px_40px_rgba(15,23,42,0.06)] md:p-7">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex items-center gap-3">
-              <span
-                className={cn(
-                  'inline-flex rounded-full px-3 py-1 text-xs font-semibold',
-                  boardCategoryStyleMap[selectedBoardPost.category],
-                )}
-              >
-                {selectedBoardPost.category}
-              </span>
-              <span className="text-sm text-slate-400">
-                {formatRelativeCreatedAt(selectedBoardPost.createdAt)}
-              </span>
+          {isBoardDetailLoading ? (
+            <div className="rounded-[24px] bg-slate-50 px-5 py-10 text-center text-sm text-slate-500">
+              게시글 상세를 불러오는 중...
             </div>
+          ) : null}
 
-            <div className="inline-flex items-center gap-1.5 text-sm text-slate-500">
-              <Heart className="h-4 w-4 text-rose-400" />
-              {selectedBoardPost.likedCount}
+          {isBoardDetailError ? (
+            <div className="rounded-[24px] border border-rose-200 bg-rose-50 px-5 py-10 text-center text-sm text-rose-600">
+              게시글 상세를 불러오지 못했어요.
+              {boardDetailError instanceof Error ? ` ${boardDetailError.message}` : ''}
             </div>
-          </div>
+          ) : null}
 
-          <h3 className="mt-5 text-[24px] font-bold tracking-[-0.03em] text-slate-900">
-            {selectedBoardPost.title}
-          </h3>
-          <p className="mt-2 text-sm font-medium text-slate-500">{selectedBoardPost.author}</p>
+          {selectedBoardPostDetail && !isBoardDetailLoading && !isBoardDetailError ? (
+            <>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <span
+                    className={cn(
+                      'inline-flex rounded-full px-3 py-1 text-xs font-semibold',
+                      boardCategoryStyleMap[selectedBoardPostDetail.category],
+                    )}
+                  >
+                    {selectedBoardPostDetail.category}
+                  </span>
+                  <span className="text-sm text-slate-400">
+                    {formatRelativeCreatedAt(selectedBoardPostDetail.createdAt)}
+                  </span>
+                </div>
 
-          <div className="mt-6 rounded-[24px] bg-slate-50 px-5 py-5 text-sm leading-7 text-slate-600">
-            게시글 상세와 댓글은 다음 이슈에서 연결 예정이에요.
-          </div>
+                <div className="flex items-center gap-3 text-sm text-slate-500">
+                  <span className="inline-flex items-center gap-1.5">
+                    <Heart className="h-4 w-4 text-rose-400" />
+                    {selectedBoardPostDetail.likedCount}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <MessageSquareText className="h-4 w-4 text-indigo-500" />
+                    {selectedBoardPostDetail.commentCount}
+                  </span>
+                </div>
+              </div>
+
+              <h3 className="mt-5 text-[24px] font-bold tracking-[-0.03em] text-slate-900">
+                {selectedBoardPostDetail.title}
+              </h3>
+              <p className="mt-2 text-sm font-medium text-slate-500">
+                {selectedBoardPostDetail.author}
+              </p>
+
+                <div className="mt-4 text-xs font-medium text-slate-400">
+                  조회 {selectedBoardPostDetailData?.viewCount ?? 0}
+                </div>
+
+              <div className="mt-6 whitespace-pre-line rounded-[24px] bg-slate-50 px-5 py-5 text-sm leading-7 text-slate-600">
+                {selectedBoardPostDetail.content}
+              </div>
+
+              <div className="mt-6 rounded-[24px] bg-slate-50 px-5 py-5 text-sm leading-7 text-slate-600">
+                댓글과 게시글 액션은 다음 이슈에서 연결 예정이에요.
+              </div>
+            </>
+          ) : null}
         </article>
       ) : null}
     </section>

--- a/src/shared/api/posts/index.ts
+++ b/src/shared/api/posts/index.ts
@@ -1,9 +1,10 @@
 export type {
   GetPostsParams,
   GetPostsResponse,
+  PostDetailResponse,
   PostListItemResponse,
   PostListPaginationResponse,
   PostListUserResponse,
 } from './posts';
-export { getPosts } from './posts';
+export { getPostDetail, getPosts } from './posts';
 export { postQueries } from './postsQueries';

--- a/src/shared/api/posts/posts.ts
+++ b/src/shared/api/posts/posts.ts
@@ -42,6 +42,19 @@ export interface GetPostsResponse {
   pagination?: PostListPaginationResponse;
 }
 
+export interface PostDetailResponse {
+  id: number;
+  userId: number;
+  categoryId?: number | null;
+  category?: string | null;
+  title: string;
+  content: string;
+  viewCount?: number | null;
+  likeCount?: number | null;
+  commentCount?: number | null;
+  createdAt: string;
+}
+
 export async function getPosts(params: GetPostsParams = {}): Promise<GetPostsResponse> {
   const response = await client.get<GetPostsResponse>('/api/v1/posts', {
     params: {
@@ -50,6 +63,12 @@ export async function getPosts(params: GetPostsParams = {}): Promise<GetPostsRes
       size: params.size,
     },
   });
+
+  return response.data;
+}
+
+export async function getPostDetail(postId: number): Promise<PostDetailResponse> {
+  const response = await client.get<PostDetailResponse>(`/api/v1/posts/${postId}`);
 
   return response.data;
 }

--- a/src/shared/api/posts/postsQueries.ts
+++ b/src/shared/api/posts/postsQueries.ts
@@ -1,5 +1,5 @@
 import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
-import { getPosts, type GetPostsParams } from '@/shared/api/posts/posts';
+import { getPostDetail, getPosts, type GetPostsParams } from '@/shared/api/posts/posts';
 
 export const postQueries = {
   all: () => ['posts'] as const,
@@ -33,5 +33,11 @@ export const postQueries = {
 
         return undefined;
       },
+    }),
+  details: () => [...postQueries.all(), 'detail'] as const,
+  detail: (postId: number) =>
+    queryOptions({
+      queryKey: [...postQueries.details(), postId],
+      queryFn: () => getPostDetail(postId),
     }),
 };


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 탭에서 선택된 게시글의 상세를 `GET /api/v1/posts/{postId}` 기반으로 실제 조회하도록 전환했습니다.
- 기존 상세 안내 문구 대신, 실제 응답을 기반으로 제목, 본문, 카테고리, 좋아요 수, 댓글 수, 조회 수, 작성 시각이 보이는 상세 카드가 렌더되도록 정리했습니다.
- 댓글과 게시글 액션은 이번 범위에서 제외하고, 후속 이슈 안내 블록만 유지했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/posts/posts.ts`에 `getPostDetail(postId)`와 상세 응답 타입 추가
- `src/shared/api/posts/postsQueries.ts`에 `postQueries.detail(postId)` 추가
- `src/shared/api/posts/index.ts` export 정리
- `src/pages/main/ui/board/MainBoardSection.tsx`에서 선택 게시글 상세 query 연결, 상세 loading / error 상태 분리, 실데이터 기반 상세 카드 렌더 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 상세 조회 연결과 상세 상태 분리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 작성자 이름은 상세 응답이 아니라 목록에서 만든 `selectedBoardPost.author` 값을 재사용합니다.
- `viewCount`는 상세 메타 정보로만 노출하고, 레이아웃은 크게 바꾸지 않았습니다.
- 댓글 / 좋아요 / 작성 / 수정 / 삭제 액션은 후속 이슈에서 다룹니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #79
