### PR TITLE
feat: (#80) 게시글 작성 연결

### DIFF
--- a/src/pages/main/ui/board/CreatePostModal.tsx
+++ b/src/pages/main/ui/board/CreatePostModal.tsx
@@ -1,0 +1,259 @@
+import axios from 'axios';
+import { useEffect, useId, useRef, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { X } from 'lucide-react';
+import { createPost, postQueries, type CreatePostResponse } from '@/shared/api/posts';
+import {
+  boardCategoryIdLabelMap,
+  boardCategoryIdMap,
+  boardCategoryOptions,
+  type MainBoardCategory,
+} from './board.constants';
+import type { MainBoardCreatedPostSyncRequest } from './types';
+
+interface CreatePostModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onRequireLogin: () => void;
+  onSuccess: (createdPost: MainBoardCreatedPostSyncRequest) => void;
+}
+
+interface CreatePostFormValues {
+  category: MainBoardCategory;
+  title: string;
+  content: string;
+}
+
+const INITIAL_CREATE_POST_FORM_VALUES: CreatePostFormValues = {
+  category: 'FREE',
+  title: '',
+  content: '',
+};
+
+const getCreatedPostCategory = (createdPost: CreatePostResponse): MainBoardCategory => {
+  if (
+    createdPost.category === 'FREE' ||
+    createdPost.category === 'REVIEW' ||
+    createdPost.category === 'INFO' ||
+    createdPost.category === 'TALK'
+  ) {
+    return createdPost.category;
+  }
+
+  if (createdPost.categoryId !== undefined && createdPost.categoryId !== null) {
+    return boardCategoryIdLabelMap[createdPost.categoryId] ?? 'FREE';
+  }
+
+  return 'FREE';
+};
+
+const CreatePostModal = ({
+  isOpen,
+  onClose,
+  onRequireLogin,
+  onSuccess,
+}: CreatePostModalProps) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const queryClient = useQueryClient();
+  const [submitError, setSubmitError] = useState('');
+  const categoryId = useId();
+  const titleId = useId();
+  const contentId = useId();
+  const createPostForm = useForm<CreatePostFormValues>({
+    defaultValues: INITIAL_CREATE_POST_FORM_VALUES,
+  });
+
+  const createPostMutation = useMutation({
+    mutationFn: createPost,
+  });
+
+  useEffect(() => {
+    const dialogElement = dialogRef.current;
+
+    if (!dialogElement) {
+      return;
+    }
+
+    if (isOpen && !dialogElement.open) {
+      dialogElement.showModal();
+      return;
+    }
+
+    if (!isOpen && dialogElement.open) {
+      dialogElement.close();
+    }
+  }, [isOpen]);
+
+  const handleClose = () => {
+    createPostForm.reset(INITIAL_CREATE_POST_FORM_VALUES);
+    setSubmitError('');
+    onClose();
+  };
+
+  const handleDialogClick = (event: React.MouseEvent<HTMLDialogElement>) => {
+    if (event.target === dialogRef.current) {
+      handleClose();
+    }
+  };
+
+  const handleCreatePostSubmit = createPostForm.handleSubmit(async (values) => {
+    const trimmedTitle = values.title.trim();
+    const trimmedContent = values.content.trim();
+
+    if (!trimmedTitle || !trimmedContent) {
+      setSubmitError('제목과 본문을 입력해주세요.');
+      return;
+    }
+
+    setSubmitError('');
+
+    try {
+      const createdPost = await createPostMutation.mutateAsync({
+        categoryId: boardCategoryIdMap[values.category],
+        title: trimmedTitle,
+        content: trimmedContent,
+      });
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: postQueries.lists() }),
+        queryClient.invalidateQueries({ queryKey: postQueries.details() }),
+      ]);
+
+      onSuccess({
+        postId: createdPost.id,
+        category: getCreatedPostCategory(createdPost),
+      });
+      handleClose();
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        const responseMessage =
+          typeof error.response?.data === 'object' &&
+          error.response?.data !== null &&
+          'message' in error.response.data &&
+          typeof error.response.data.message === 'string'
+            ? error.response.data.message
+            : '';
+
+        if (status === 401) {
+          setSubmitError('로그인 후 게시글을 작성할 수 있어요.');
+          onRequireLogin();
+          return;
+        }
+
+        if (status === 400) {
+          setSubmitError(responseMessage || '입력한 내용을 다시 확인해주세요.');
+          return;
+        }
+
+        if (status === 404) {
+          setSubmitError('게시글 카테고리를 찾을 수 없어요.');
+          return;
+        }
+      }
+
+      setSubmitError('게시글을 작성하지 못했어요. 잠시 후 다시 시도해주세요.');
+    }
+  });
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={handleClose}
+      onClick={handleDialogClick}
+      className="backdrop:bg-slate-950/50 w-full max-w-2xl rounded-[32px] bg-white p-0 text-left shadow-[0_24px_80px_rgba(15,23,42,0.22)] backdrop:backdrop-blur-[2px]"
+    >
+      <div className="p-6 md:p-7">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold text-indigo-500">게시글 작성</p>
+            <h2 className="mt-1 text-[24px] font-bold tracking-[-0.03em] text-slate-900">
+              점심 메이트와 이야기를 나눠보세요
+            </h2>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleClose}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-100 text-slate-500 transition hover:bg-slate-200"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <form className="mt-6" onSubmit={handleCreatePostSubmit}>
+          <div className="grid gap-4">
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-semibold text-slate-700">카테고리</span>
+              <select
+                id={categoryId}
+                className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+                {...createPostForm.register('category', { required: true })}
+              >
+                {boardCategoryOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-semibold text-slate-700">제목</span>
+              <input
+                id={titleId}
+                type="text"
+                placeholder="제목을 입력해주세요"
+                className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+                {...createPostForm.register('title', {
+                  required: true,
+                  validate: (value) => value.trim().length > 0,
+                })}
+              />
+            </label>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-semibold text-slate-700">본문</span>
+              <textarea
+                id={contentId}
+                rows={8}
+                placeholder="게시글 내용을 입력해주세요"
+                className="min-h-[220px] rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+                {...createPostForm.register('content', {
+                  required: true,
+                  validate: (value) => value.trim().length > 0,
+                })}
+              />
+            </label>
+          </div>
+
+          {submitError ? (
+            <p className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-600">
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="mt-6 flex flex-col-reverse gap-3 md:flex-row md:justify-end">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="rounded-2xl border border-slate-200 px-5 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
+            >
+              닫기
+            </button>
+            <button
+              type="submit"
+              disabled={createPostMutation.isPending}
+              className="rounded-2xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(99,102,241,0.28)] transition hover:bg-indigo-600 disabled:cursor-not-allowed disabled:bg-indigo-300"
+            >
+              {createPostMutation.isPending ? '작성 중...' : '게시글 작성'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </dialog>
+  );
+};
+
+export default CreatePostModal;

--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -7,7 +7,7 @@ import {
   type PostListItemResponse,
 } from '@/shared/api/posts';
 import { cn } from '@/shared/lib/utils';
-import type { MainBoardPost } from './types';
+import type { MainBoardCreatedPostSyncRequest, MainBoardPost } from './types';
 import {
   boardCategoryFilterOptions,
   boardCategoryIdLabelMap,
@@ -106,9 +106,18 @@ const toMainBoardPostDetail = (
   createdAt: post.createdAt,
 });
 
-const MainBoardSection = () => {
+interface MainBoardSectionProps {
+  createdPostSyncRequest: MainBoardCreatedPostSyncRequest | null;
+  onCreatedPostSyncHandled: () => void;
+}
+
+const MainBoardSection = ({
+  createdPostSyncRequest,
+  onCreatedPostSyncHandled,
+}: MainBoardSectionProps) => {
   const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<MainBoardCategoryFilter>('ALL');
+  const [pendingCreatedPostId, setPendingCreatedPostId] = useState<number | null>(null);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const categoryId =
     selectedCategory === 'ALL' ? undefined : boardCategoryIdMap[selectedCategory];
@@ -119,6 +128,7 @@ const MainBoardSection = () => {
     error,
     fetchNextPage,
     hasNextPage,
+    isFetching,
     isFetchingNextPage,
     isFetchNextPageError,
   } = useInfiniteQuery(
@@ -149,9 +159,43 @@ const MainBoardSection = () => {
   const hasLoadedPosts = data !== undefined;
 
   useEffect(() => {
+    if (!createdPostSyncRequest) {
+      return;
+    }
+
+    if (selectedCategory !== 'ALL' && selectedCategory !== createdPostSyncRequest.category) {
+      setSelectedCategory(createdPostSyncRequest.category);
+    }
+
+    setPendingCreatedPostId(createdPostSyncRequest.postId);
+    setSelectedBoardPostId(createdPostSyncRequest.postId);
+    onCreatedPostSyncHandled();
+  }, [createdPostSyncRequest, onCreatedPostSyncHandled, selectedCategory]);
+
+  useEffect(() => {
     if (boardPosts.length === 0) {
+      if (pendingCreatedPostId !== null && isFetching) {
+        return;
+      }
+
       setSelectedBoardPostId(null);
       return;
+    }
+
+    if (pendingCreatedPostId !== null) {
+      const hasPendingCreatedPost = boardPosts.some(
+        (boardPost) => boardPost.id === pendingCreatedPostId,
+      );
+
+      if (hasPendingCreatedPost) {
+        setSelectedBoardPostId(pendingCreatedPostId);
+        setPendingCreatedPostId(null);
+        return;
+      }
+
+      if (isFetching) {
+        return;
+      }
     }
 
     const hasSelectedBoardPost =
@@ -160,7 +204,7 @@ const MainBoardSection = () => {
     if (!hasSelectedBoardPost) {
       setSelectedBoardPostId(boardPosts[0].id);
     }
-  }, [boardPosts, selectedBoardPostId]);
+  }, [boardPosts, isFetching, pendingCreatedPostId, selectedBoardPostId]);
 
   useEffect(() => {
     const target = loadMoreRef.current;

--- a/src/pages/main/ui/board/board.constants.ts
+++ b/src/pages/main/ui/board/board.constants.ts
@@ -24,13 +24,17 @@ export const boardCategoryIdLabelMap: Record<number, MainBoardCategory> = {
   4: 'TALK',
 };
 
-export const boardCategoryFilterOptions: Array<{
-  value: MainBoardCategoryFilter;
+export const boardCategoryOptions: Array<{
+  value: MainBoardCategory;
   label: string;
 }> = [
-  { value: 'ALL', label: '전체' },
   { value: 'FREE', label: '자유' },
   { value: 'REVIEW', label: '리뷰' },
   { value: 'INFO', label: '정보' },
   { value: 'TALK', label: '잡담' },
 ];
+
+export const boardCategoryFilterOptions: Array<{
+  value: MainBoardCategoryFilter;
+  label: string;
+}> = [{ value: 'ALL', label: '전체' }, ...boardCategoryOptions];

--- a/src/pages/main/ui/board/types.ts
+++ b/src/pages/main/ui/board/types.ts
@@ -10,6 +10,11 @@ export interface MainBoardPost {
   createdAt: string;
 }
 
+export interface MainBoardCreatedPostSyncRequest {
+  postId: number;
+  category: MainBoardPost['category'];
+}
+
 export interface MainBoardComment {
   id: number;
   postId: number;

--- a/src/pages/main/ui/layout/MainPage.tsx
+++ b/src/pages/main/ui/layout/MainPage.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import LoginModal from '../auth/LoginModal';
+import CreatePostModal from '../board/CreatePostModal';
+import type { MainBoardCreatedPostSyncRequest } from '../board/types';
 import CreateRoomModal from '../room/CreateRoomModal';
 import MainHeader from './MainHeader';
 import MainHero from './MainHero';
@@ -11,6 +13,9 @@ const MainPage = () => {
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<MainTab>('ROOM');
   const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false);
+  const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState(false);
+  const [createdPostSyncRequest, setCreatedPostSyncRequest] =
+    useState<MainBoardCreatedPostSyncRequest | null>(null);
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -22,6 +27,9 @@ const MainPage = () => {
         <MainTabSection
           activeTab={activeTab}
           onCreateRoomClick={() => setIsCreateRoomModalOpen(true)}
+          onCreatePostClick={() => setIsCreatePostModalOpen(true)}
+          createdPostSyncRequest={createdPostSyncRequest}
+          onCreatedPostSyncHandled={() => setCreatedPostSyncRequest(null)}
         />
       </main>
 
@@ -29,6 +37,14 @@ const MainPage = () => {
       <CreateRoomModal
         isOpen={isCreateRoomModalOpen}
         onClose={() => setIsCreateRoomModalOpen(false)}
+      />
+      <CreatePostModal
+        isOpen={isCreatePostModalOpen}
+        onClose={() => setIsCreatePostModalOpen(false)}
+        onRequireLogin={() => setIsLoginModalOpen(true)}
+        onSuccess={(createdPost) => {
+          setCreatedPostSyncRequest(createdPost);
+        }}
       />
     </div>
   );

--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -1,6 +1,7 @@
 import { Plus } from 'lucide-react';
 import type { MainTab } from '../../model/types';
 import MainBoardSection from '../board/MainBoardSection';
+import type { MainBoardCreatedPostSyncRequest } from '../board/types';
 import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
 import { mockRooms } from '../room/mockRooms';
@@ -10,6 +11,9 @@ import RoomSummary from '../room/RoomSummary';
 interface MainTabSectionProps {
   activeTab: MainTab;
   onCreateRoomClick: () => void;
+  onCreatePostClick: () => void;
+  createdPostSyncRequest: MainBoardCreatedPostSyncRequest | null;
+  onCreatedPostSyncHandled: () => void;
 }
 
 const tabDescriptionMap: Record<MainTab, string> = {
@@ -19,8 +23,15 @@ const tabDescriptionMap: Record<MainTab, string> = {
   BOARD: '자유게시판에서 점심메이트와 가볍게 소통해보세요.',
 };
 
-const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) => {
+const MainTabSection = ({
+  activeTab,
+  onCreateRoomClick,
+  onCreatePostClick,
+  createdPostSyncRequest,
+  onCreatedPostSyncHandled,
+}: MainTabSectionProps) => {
   const isRoomTab = activeTab === 'ROOM';
+  const isBoardTab = activeTab === 'BOARD';
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -32,14 +43,14 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
           <p className="mt-2 text-sm leading-6 text-slate-500">{tabDescriptionMap[activeTab]}</p>
         </div>
 
-        {isRoomTab ? (
+        {isRoomTab || isBoardTab ? (
           <button
             type="button"
-            onClick={onCreateRoomClick}
+            onClick={isRoomTab ? onCreateRoomClick : onCreatePostClick}
             className="inline-flex items-center justify-center gap-2 rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
           >
             <Plus className="h-4 w-4" />
-            방 만들기
+            {isRoomTab ? '방 만들기' : '게시글 작성'}
           </button>
         ) : null}
       </div>
@@ -56,7 +67,12 @@ const MainTabSection = ({ activeTab, onCreateRoomClick }: MainTabSectionProps) =
 
       {activeTab === 'LUNCH' ? <MainLunchMenuSection /> : null}
       {activeTab === 'RANKING' ? <MainRankingSection /> : null}
-      {activeTab === 'BOARD' ? <MainBoardSection /> : null}
+      {activeTab === 'BOARD' ? (
+        <MainBoardSection
+          createdPostSyncRequest={createdPostSyncRequest}
+          onCreatedPostSyncHandled={onCreatedPostSyncHandled}
+        />
+      ) : null}
     </section>
   );
 };

--- a/src/shared/api/posts/index.ts
+++ b/src/shared/api/posts/index.ts
@@ -1,4 +1,6 @@
 export type {
+  CreatePostRequest,
+  CreatePostResponse,
   GetPostsParams,
   GetPostsResponse,
   PostDetailResponse,
@@ -6,5 +8,5 @@ export type {
   PostListPaginationResponse,
   PostListUserResponse,
 } from './posts';
-export { getPostDetail, getPosts } from './posts';
+export { createPost, getPostDetail, getPosts } from './posts';
 export { postQueries } from './postsQueries';

--- a/src/shared/api/posts/posts.ts
+++ b/src/shared/api/posts/posts.ts
@@ -42,6 +42,22 @@ export interface GetPostsResponse {
   pagination?: PostListPaginationResponse;
 }
 
+export interface CreatePostRequest {
+  categoryId: number;
+  title: string;
+  content: string;
+}
+
+export interface CreatePostResponse {
+  id: number;
+  userId?: number;
+  categoryId?: number | null;
+  category?: string | null;
+  title: string;
+  content: string;
+  createdAt: string;
+}
+
 export interface PostDetailResponse {
   id: number;
   userId: number;
@@ -63,6 +79,12 @@ export async function getPosts(params: GetPostsParams = {}): Promise<GetPostsRes
       size: params.size,
     },
   });
+
+  return response.data;
+}
+
+export async function createPost(payload: CreatePostRequest): Promise<CreatePostResponse> {
+  const response = await client.post<CreatePostResponse>('/api/v1/posts', payload);
 
   return response.data;
 }


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 탭에 `POST /api/v1/posts` 기반 게시글 작성 기능을 연결했습니다.
- BOARD 상단 우측 CTA와 `CreatePostModal`을 추가해 카테고리, 제목, 본문을 입력할 수 있는 작성 흐름을 붙였습니다.
- 작성 성공 후 목록을 갱신하고, 새 글이 보이도록 카테고리 필터와 선택 상태를 정리해 상세를 바로 확인할 수 있도록 맞췄습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/posts/posts.ts`에 `createPost(payload)`와 생성 요청 / 응답 타입 추가
- `src/shared/api/posts/index.ts` export 정리
- `src/pages/main/ui/board/CreatePostModal.tsx` 추가
- `src/pages/main/ui/board/MainBoardSection.tsx`에 생성 후 필터 / 선택 상태 동기화 연결
- `src/pages/main/ui/layout/MainPage.tsx`, `src/pages/main/ui/layout/MainTabSection.tsx`에 BOARD 작성 CTA와 모달 상태 연결
- `src/pages/main/ui/board/board.constants.ts`, `src/pages/main/ui/board/types.ts`에 작성 모달 / 생성 동기화용 타입 확장

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 작성 연결과 작성 성공 후 상태 동기화 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 작성 성공 / 실패 피드백은 BOARD 공용 메시지 대신 모달 내부에서 처리합니다.
- `401` 응답은 `로그인 후 게시글을 작성할 수 있어요.` 문구와 함께 로그인 모달을 열도록 연결했습니다.
- 새 글이 현재 필터에 보이지 않는 경우 생성된 글 카테고리 기준으로 필터를 맞춘 뒤 해당 글을 선택합니다.
- 댓글 / 좋아요 / 수정 / 삭제 액션은 후속 이슈에서 다룹니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #80
