### PR TITLE
feat: (#81) 게시글 수정 연결

### DIFF
--- a/src/pages/main/ui/board/CreatePostModal.tsx
+++ b/src/pages/main/ui/board/CreatePostModal.tsx
@@ -1,25 +1,34 @@
 import axios from 'axios';
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { X } from 'lucide-react';
-import { createPost, postQueries, type CreatePostResponse } from '@/shared/api/posts';
+import {
+  createPost,
+  postQueries,
+  updatePost,
+  type CreatePostResponse,
+  type PostDetailResponse,
+} from '@/shared/api/posts';
 import {
   boardCategoryIdLabelMap,
   boardCategoryIdMap,
   boardCategoryOptions,
   type MainBoardCategory,
 } from './board.constants';
-import type { MainBoardCreatedPostSyncRequest } from './types';
+import type { MainBoardPostSyncRequest } from './types';
 
 interface CreatePostModalProps {
   isOpen: boolean;
   onClose: () => void;
   onRequireLogin: () => void;
-  onSuccess: (createdPost: MainBoardCreatedPostSyncRequest) => void;
+  onSuccess: (post: MainBoardPostSyncRequest) => void;
+  mode?: 'create' | 'edit';
+  postId?: number;
+  initialValues?: CreatePostFormValues;
 }
 
-interface CreatePostFormValues {
+export interface CreatePostFormValues {
   category: MainBoardCategory;
   title: string;
   content: string;
@@ -31,21 +40,26 @@ const INITIAL_CREATE_POST_FORM_VALUES: CreatePostFormValues = {
   content: '',
 };
 
-const getCreatedPostCategory = (createdPost: CreatePostResponse): MainBoardCategory => {
+const toPostCategory = (
+  post:
+    | Pick<CreatePostResponse, 'category' | 'categoryId'>
+    | Pick<PostDetailResponse, 'category' | 'categoryId'>,
+  fallbackCategory: MainBoardCategory = 'FREE',
+): MainBoardCategory => {
   if (
-    createdPost.category === 'FREE' ||
-    createdPost.category === 'REVIEW' ||
-    createdPost.category === 'INFO' ||
-    createdPost.category === 'TALK'
+    post.category === 'FREE' ||
+    post.category === 'REVIEW' ||
+    post.category === 'INFO' ||
+    post.category === 'TALK'
   ) {
-    return createdPost.category;
+    return post.category;
   }
 
-  if (createdPost.categoryId !== undefined && createdPost.categoryId !== null) {
-    return boardCategoryIdLabelMap[createdPost.categoryId] ?? 'FREE';
+  if (post.categoryId !== undefined && post.categoryId !== null) {
+    return boardCategoryIdLabelMap[post.categoryId] ?? fallbackCategory;
   }
 
-  return 'FREE';
+  return fallbackCategory;
 };
 
 const CreatePostModal = ({
@@ -53,6 +67,9 @@ const CreatePostModal = ({
   onClose,
   onRequireLogin,
   onSuccess,
+  mode = 'create',
+  postId,
+  initialValues,
 }: CreatePostModalProps) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const queryClient = useQueryClient();
@@ -60,12 +77,36 @@ const CreatePostModal = ({
   const categoryId = useId();
   const titleId = useId();
   const contentId = useId();
+  const defaultFormValues = useMemo<CreatePostFormValues>(
+    () => ({
+      category: initialValues?.category ?? INITIAL_CREATE_POST_FORM_VALUES.category,
+      title: initialValues?.title ?? INITIAL_CREATE_POST_FORM_VALUES.title,
+      content: initialValues?.content ?? INITIAL_CREATE_POST_FORM_VALUES.content,
+    }),
+    [initialValues?.category, initialValues?.content, initialValues?.title],
+  );
   const createPostForm = useForm<CreatePostFormValues>({
-    defaultValues: INITIAL_CREATE_POST_FORM_VALUES,
+    defaultValues: defaultFormValues,
   });
 
-  const createPostMutation = useMutation({
-    mutationFn: createPost,
+  const submitPostMutation = useMutation({
+    mutationFn: async (values: CreatePostFormValues) => {
+      const normalizedPayload = {
+        categoryId: boardCategoryIdMap[values.category],
+        title: values.title.trim(),
+        content: values.content.trim(),
+      };
+
+      if (mode === 'edit') {
+        if (!postId) {
+          throw new Error('게시글 id가 없어요.');
+        }
+
+        return updatePost(postId, normalizedPayload);
+      }
+
+      return createPost(normalizedPayload);
+    },
   });
 
   useEffect(() => {
@@ -85,8 +126,17 @@ const CreatePostModal = ({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    createPostForm.reset(defaultFormValues);
+    setSubmitError('');
+  }, [createPostForm, defaultFormValues, isOpen]);
+
   const handleClose = () => {
-    createPostForm.reset(INITIAL_CREATE_POST_FORM_VALUES);
+    createPostForm.reset(defaultFormValues);
     setSubmitError('');
     onClose();
   };
@@ -97,7 +147,7 @@ const CreatePostModal = ({
     }
   };
 
-  const handleCreatePostSubmit = createPostForm.handleSubmit(async (values) => {
+  const handleSubmit = createPostForm.handleSubmit(async (values) => {
     const trimmedTitle = values.title.trim();
     const trimmedContent = values.content.trim();
 
@@ -109,8 +159,8 @@ const CreatePostModal = ({
     setSubmitError('');
 
     try {
-      const createdPost = await createPostMutation.mutateAsync({
-        categoryId: boardCategoryIdMap[values.category],
+      const syncedPost = await submitPostMutation.mutateAsync({
+        category: values.category,
         title: trimmedTitle,
         content: trimmedContent,
       });
@@ -121,8 +171,8 @@ const CreatePostModal = ({
       ]);
 
       onSuccess({
-        postId: createdPost.id,
-        category: getCreatedPostCategory(createdPost),
+        postId: syncedPost.id,
+        category: toPostCategory(syncedPost, values.category),
       });
       handleClose();
     } catch (error) {
@@ -137,7 +187,11 @@ const CreatePostModal = ({
             : '';
 
         if (status === 401) {
-          setSubmitError('로그인 후 게시글을 작성할 수 있어요.');
+          setSubmitError(
+            mode === 'edit'
+              ? '로그인 후 게시글을 수정할 수 있어요.'
+              : '로그인 후 게시글을 작성할 수 있어요.',
+          );
           onRequireLogin();
           return;
         }
@@ -147,13 +201,24 @@ const CreatePostModal = ({
           return;
         }
 
+        if (status === 403) {
+          setSubmitError('게시글을 수정할 권한이 없어요.');
+          return;
+        }
+
         if (status === 404) {
-          setSubmitError('게시글 카테고리를 찾을 수 없어요.');
+          setSubmitError(
+            mode === 'edit' ? '게시글을 찾을 수 없어요.' : '게시글 카테고리를 찾을 수 없어요.',
+          );
           return;
         }
       }
 
-      setSubmitError('게시글을 작성하지 못했어요. 잠시 후 다시 시도해주세요.');
+      setSubmitError(
+        mode === 'edit'
+          ? '게시글을 수정하지 못했어요. 잠시 후 다시 시도해주세요.'
+          : '게시글을 작성하지 못했어요. 잠시 후 다시 시도해주세요.',
+      );
     }
   });
 
@@ -167,9 +232,13 @@ const CreatePostModal = ({
       <div className="p-6 md:p-7">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <p className="text-sm font-semibold text-indigo-500">게시글 작성</p>
+            <p className="text-sm font-semibold text-indigo-500">
+              {mode === 'edit' ? '게시글 수정' : '게시글 작성'}
+            </p>
             <h2 className="mt-1 text-[24px] font-bold tracking-[-0.03em] text-slate-900">
-              점심 메이트와 이야기를 나눠보세요
+              {mode === 'edit'
+                ? '게시글 내용을 최신 상태로 정리해보세요'
+                : '점심 메이트와 이야기를 나눠보세요'}
             </h2>
           </div>
 
@@ -182,7 +251,7 @@ const CreatePostModal = ({
           </button>
         </div>
 
-        <form className="mt-6" onSubmit={handleCreatePostSubmit}>
+        <form className="mt-6" onSubmit={handleSubmit}>
           <div className="grid gap-4">
             <label className="flex flex-col gap-2">
               <span className="text-sm font-semibold text-slate-700">카테고리</span>
@@ -244,10 +313,16 @@ const CreatePostModal = ({
             </button>
             <button
               type="submit"
-              disabled={createPostMutation.isPending}
+              disabled={submitPostMutation.isPending}
               className="rounded-2xl bg-indigo-500 px-5 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(99,102,241,0.28)] transition hover:bg-indigo-600 disabled:cursor-not-allowed disabled:bg-indigo-300"
             >
-              {createPostMutation.isPending ? '작성 중...' : '게시글 작성'}
+              {submitPostMutation.isPending
+                ? mode === 'edit'
+                  ? '수정 중...'
+                  : '작성 중...'
+                : mode === 'edit'
+                  ? '게시글 수정'
+                  : '게시글 작성'}
             </button>
           </div>
         </form>

--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -1,4 +1,4 @@
-import { Heart, MessageSquareText } from 'lucide-react';
+import { Heart, MessageSquareText, PencilLine } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import {
@@ -6,8 +6,9 @@ import {
   type PostDetailResponse,
   type PostListItemResponse,
 } from '@/shared/api/posts';
+import { myUserQueryOptions } from '@/shared/api/users/meQueries';
 import { cn } from '@/shared/lib/utils';
-import type { MainBoardCreatedPostSyncRequest, MainBoardPost } from './types';
+import type { MainBoardPost, MainBoardPostSyncRequest } from './types';
 import {
   boardCategoryFilterOptions,
   boardCategoryIdLabelMap,
@@ -15,6 +16,7 @@ import {
   boardCategoryStyleMap,
   type MainBoardCategoryFilter,
 } from './board.constants';
+import CreatePostModal, { type CreatePostFormValues } from './CreatePostModal';
 
 const BOARD_LIST_DEFAULT_PAGE = 1;
 const BOARD_LIST_DEFAULT_SIZE = 10;
@@ -39,7 +41,11 @@ const formatRelativeCreatedAt = (createdAt: string) => {
   return `${diffDays}일 전`;
 };
 
-const toBoardCategory = (post: PostListItemResponse): MainBoardPost['category'] => {
+const toBoardCategory = (
+  post:
+    | Pick<PostListItemResponse, 'category' | 'categoryId'>
+    | Pick<PostDetailResponse, 'category' | 'categoryId'>,
+): MainBoardPost['category'] => {
   if (
     post.category === 'FREE' ||
     post.category === 'REVIEW' ||
@@ -106,21 +112,31 @@ const toMainBoardPostDetail = (
   createdAt: post.createdAt,
 });
 
+const toEditPostFormValues = (post: MainBoardPost): CreatePostFormValues => ({
+  category: post.category,
+  title: post.title,
+  content: post.content,
+});
+
 interface MainBoardSectionProps {
-  createdPostSyncRequest: MainBoardCreatedPostSyncRequest | null;
-  onCreatedPostSyncHandled: () => void;
+  postSyncRequest: MainBoardPostSyncRequest | null;
+  onPostSyncHandled: () => void;
+  onRequireLogin: () => void;
 }
 
 const MainBoardSection = ({
-  createdPostSyncRequest,
-  onCreatedPostSyncHandled,
+  postSyncRequest,
+  onPostSyncHandled,
+  onRequireLogin,
 }: MainBoardSectionProps) => {
   const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<MainBoardCategoryFilter>('ALL');
-  const [pendingCreatedPostId, setPendingCreatedPostId] = useState<number | null>(null);
+  const [pendingSyncedPostId, setPendingSyncedPostId] = useState<number | null>(null);
+  const [isEditPostModalOpen, setIsEditPostModalOpen] = useState(false);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const categoryId =
     selectedCategory === 'ALL' ? undefined : boardCategoryIdMap[selectedCategory];
+  const { data: myUserData } = useQuery(myUserQueryOptions());
   const {
     data,
     isLoading,
@@ -156,25 +172,27 @@ const MainBoardSection = ({
     selectedBoardPostDetailData && selectedBoardPost
       ? toMainBoardPostDetail(selectedBoardPostDetailData, selectedBoardPost.author)
       : null;
+  const canEditSelectedPost =
+    selectedBoardPostDetailData !== undefined && myUserData?.id === selectedBoardPostDetailData.userId;
   const hasLoadedPosts = data !== undefined;
 
   useEffect(() => {
-    if (!createdPostSyncRequest) {
+    if (!postSyncRequest) {
       return;
     }
 
-    if (selectedCategory !== 'ALL' && selectedCategory !== createdPostSyncRequest.category) {
-      setSelectedCategory(createdPostSyncRequest.category);
+    if (selectedCategory !== 'ALL' && selectedCategory !== postSyncRequest.category) {
+      setSelectedCategory(postSyncRequest.category);
     }
 
-    setPendingCreatedPostId(createdPostSyncRequest.postId);
-    setSelectedBoardPostId(createdPostSyncRequest.postId);
-    onCreatedPostSyncHandled();
-  }, [createdPostSyncRequest, onCreatedPostSyncHandled, selectedCategory]);
+    setPendingSyncedPostId(postSyncRequest.postId);
+    setSelectedBoardPostId(postSyncRequest.postId);
+    onPostSyncHandled();
+  }, [onPostSyncHandled, postSyncRequest, selectedCategory]);
 
   useEffect(() => {
     if (boardPosts.length === 0) {
-      if (pendingCreatedPostId !== null && isFetching) {
+      if (pendingSyncedPostId !== null && isFetching) {
         return;
       }
 
@@ -182,14 +200,14 @@ const MainBoardSection = ({
       return;
     }
 
-    if (pendingCreatedPostId !== null) {
-      const hasPendingCreatedPost = boardPosts.some(
-        (boardPost) => boardPost.id === pendingCreatedPostId,
+    if (pendingSyncedPostId !== null) {
+      const hasPendingSyncedPost = boardPosts.some(
+        (boardPost) => boardPost.id === pendingSyncedPostId,
       );
 
-      if (hasPendingCreatedPost) {
-        setSelectedBoardPostId(pendingCreatedPostId);
-        setPendingCreatedPostId(null);
+      if (hasPendingSyncedPost) {
+        setSelectedBoardPostId(pendingSyncedPostId);
+        setPendingSyncedPostId(null);
         return;
       }
 
@@ -199,12 +217,13 @@ const MainBoardSection = ({
     }
 
     const hasSelectedBoardPost =
-      selectedBoardPostId !== null && boardPosts.some((boardPost) => boardPost.id === selectedBoardPostId);
+      selectedBoardPostId !== null &&
+      boardPosts.some((boardPost) => boardPost.id === selectedBoardPostId);
 
     if (!hasSelectedBoardPost) {
       setSelectedBoardPostId(boardPosts[0].id);
     }
-  }, [boardPosts, isFetching, pendingCreatedPostId, selectedBoardPostId]);
+  }, [boardPosts, isFetching, pendingSyncedPostId, selectedBoardPostId]);
 
   useEffect(() => {
     const target = loadMoreRef.current;
@@ -379,15 +398,28 @@ const MainBoardSection = ({
                   </span>
                 </div>
 
-                <div className="flex items-center gap-3 text-sm text-slate-500">
-                  <span className="inline-flex items-center gap-1.5">
-                    <Heart className="h-4 w-4 text-rose-400" />
-                    {selectedBoardPostDetail.likedCount}
-                  </span>
-                  <span className="inline-flex items-center gap-1.5">
-                    <MessageSquareText className="h-4 w-4 text-indigo-500" />
-                    {selectedBoardPostDetail.commentCount}
-                  </span>
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 text-sm text-slate-500">
+                    <span className="inline-flex items-center gap-1.5">
+                      <Heart className="h-4 w-4 text-rose-400" />
+                      {selectedBoardPostDetail.likedCount}
+                    </span>
+                    <span className="inline-flex items-center gap-1.5">
+                      <MessageSquareText className="h-4 w-4 text-indigo-500" />
+                      {selectedBoardPostDetail.commentCount}
+                    </span>
+                  </div>
+
+                  {canEditSelectedPost ? (
+                    <button
+                      type="button"
+                      onClick={() => setIsEditPostModalOpen(true)}
+                      className="inline-flex items-center gap-1.5 rounded-2xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
+                    >
+                      <PencilLine className="h-4 w-4" />
+                      게시글 수정
+                    </button>
+                  ) : null}
                 </div>
               </div>
 
@@ -398,9 +430,9 @@ const MainBoardSection = ({
                 {selectedBoardPostDetail.author}
               </p>
 
-                <div className="mt-4 text-xs font-medium text-slate-400">
-                  조회 {selectedBoardPostDetailData?.viewCount ?? 0}
-                </div>
+              <div className="mt-4 text-xs font-medium text-slate-400">
+                조회 {selectedBoardPostDetailData?.viewCount ?? 0}
+              </div>
 
               <div className="mt-6 whitespace-pre-line rounded-[24px] bg-slate-50 px-5 py-5 text-sm leading-7 text-slate-600">
                 {selectedBoardPostDetail.content}
@@ -412,6 +444,25 @@ const MainBoardSection = ({
             </>
           ) : null}
         </article>
+      ) : null}
+
+      {selectedBoardPostDetail ? (
+        <CreatePostModal
+          isOpen={isEditPostModalOpen}
+          mode="edit"
+          postId={selectedBoardPostDetail.id}
+          initialValues={toEditPostFormValues(selectedBoardPostDetail)}
+          onClose={() => setIsEditPostModalOpen(false)}
+          onRequireLogin={onRequireLogin}
+          onSuccess={(post) => {
+            setPendingSyncedPostId(post.postId);
+            setSelectedBoardPostId(post.postId);
+
+            if (selectedCategory !== 'ALL' && selectedCategory !== post.category) {
+              setSelectedCategory(post.category);
+            }
+          }}
+        />
       ) : null}
     </section>
   );

--- a/src/pages/main/ui/board/types.ts
+++ b/src/pages/main/ui/board/types.ts
@@ -10,7 +10,7 @@ export interface MainBoardPost {
   createdAt: string;
 }
 
-export interface MainBoardCreatedPostSyncRequest {
+export interface MainBoardPostSyncRequest {
   postId: number;
   category: MainBoardPost['category'];
 }

--- a/src/pages/main/ui/layout/MainPage.tsx
+++ b/src/pages/main/ui/layout/MainPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import LoginModal from '../auth/LoginModal';
 import CreatePostModal from '../board/CreatePostModal';
-import type { MainBoardCreatedPostSyncRequest } from '../board/types';
+import type { MainBoardPostSyncRequest } from '../board/types';
 import CreateRoomModal from '../room/CreateRoomModal';
 import MainHeader from './MainHeader';
 import MainHero from './MainHero';
@@ -14,8 +14,7 @@ const MainPage = () => {
   const [activeTab, setActiveTab] = useState<MainTab>('ROOM');
   const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false);
   const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState(false);
-  const [createdPostSyncRequest, setCreatedPostSyncRequest] =
-    useState<MainBoardCreatedPostSyncRequest | null>(null);
+  const [postSyncRequest, setPostSyncRequest] = useState<MainBoardPostSyncRequest | null>(null);
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -28,8 +27,9 @@ const MainPage = () => {
           activeTab={activeTab}
           onCreateRoomClick={() => setIsCreateRoomModalOpen(true)}
           onCreatePostClick={() => setIsCreatePostModalOpen(true)}
-          createdPostSyncRequest={createdPostSyncRequest}
-          onCreatedPostSyncHandled={() => setCreatedPostSyncRequest(null)}
+          postSyncRequest={postSyncRequest}
+          onPostSyncHandled={() => setPostSyncRequest(null)}
+          onRequireLogin={() => setIsLoginModalOpen(true)}
         />
       </main>
 
@@ -42,8 +42,8 @@ const MainPage = () => {
         isOpen={isCreatePostModalOpen}
         onClose={() => setIsCreatePostModalOpen(false)}
         onRequireLogin={() => setIsLoginModalOpen(true)}
-        onSuccess={(createdPost) => {
-          setCreatedPostSyncRequest(createdPost);
+        onSuccess={(post) => {
+          setPostSyncRequest(post);
         }}
       />
     </div>

--- a/src/pages/main/ui/layout/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/MainTabSection.tsx
@@ -1,7 +1,7 @@
 import { Plus } from 'lucide-react';
 import type { MainTab } from '../../model/types';
 import MainBoardSection from '../board/MainBoardSection';
-import type { MainBoardCreatedPostSyncRequest } from '../board/types';
+import type { MainBoardPostSyncRequest } from '../board/types';
 import MainLunchMenuSection from '../lunch/MainLunchMenuSection';
 import MainRankingSection from '../ranking/MainRankingSection';
 import { mockRooms } from '../room/mockRooms';
@@ -12,8 +12,9 @@ interface MainTabSectionProps {
   activeTab: MainTab;
   onCreateRoomClick: () => void;
   onCreatePostClick: () => void;
-  createdPostSyncRequest: MainBoardCreatedPostSyncRequest | null;
-  onCreatedPostSyncHandled: () => void;
+  postSyncRequest: MainBoardPostSyncRequest | null;
+  onPostSyncHandled: () => void;
+  onRequireLogin: () => void;
 }
 
 const tabDescriptionMap: Record<MainTab, string> = {
@@ -27,8 +28,9 @@ const MainTabSection = ({
   activeTab,
   onCreateRoomClick,
   onCreatePostClick,
-  createdPostSyncRequest,
-  onCreatedPostSyncHandled,
+  postSyncRequest,
+  onPostSyncHandled,
+  onRequireLogin,
 }: MainTabSectionProps) => {
   const isRoomTab = activeTab === 'ROOM';
   const isBoardTab = activeTab === 'BOARD';
@@ -69,8 +71,9 @@ const MainTabSection = ({
       {activeTab === 'RANKING' ? <MainRankingSection /> : null}
       {activeTab === 'BOARD' ? (
         <MainBoardSection
-          createdPostSyncRequest={createdPostSyncRequest}
-          onCreatedPostSyncHandled={onCreatedPostSyncHandled}
+          postSyncRequest={postSyncRequest}
+          onPostSyncHandled={onPostSyncHandled}
+          onRequireLogin={onRequireLogin}
         />
       ) : null}
     </section>

--- a/src/shared/api/posts/index.ts
+++ b/src/shared/api/posts/index.ts
@@ -7,6 +7,7 @@ export type {
   PostListItemResponse,
   PostListPaginationResponse,
   PostListUserResponse,
+  UpdatePostRequest,
 } from './posts';
-export { createPost, getPostDetail, getPosts } from './posts';
+export { createPost, getPostDetail, getPosts, updatePost } from './posts';
 export { postQueries } from './postsQueries';

--- a/src/shared/api/posts/posts.ts
+++ b/src/shared/api/posts/posts.ts
@@ -58,6 +58,12 @@ export interface CreatePostResponse {
   createdAt: string;
 }
 
+export interface UpdatePostRequest {
+  categoryId?: number;
+  title?: string;
+  content?: string;
+}
+
 export interface PostDetailResponse {
   id: number;
   userId: number;
@@ -85,6 +91,15 @@ export async function getPosts(params: GetPostsParams = {}): Promise<GetPostsRes
 
 export async function createPost(payload: CreatePostRequest): Promise<CreatePostResponse> {
   const response = await client.post<CreatePostResponse>('/api/v1/posts', payload);
+
+  return response.data;
+}
+
+export async function updatePost(
+  postId: number,
+  payload: UpdatePostRequest,
+): Promise<PostDetailResponse> {
+  const response = await client.patch<PostDetailResponse>(`/api/v1/posts/${postId}`, payload);
 
   return response.data;
 }

--- a/src/shared/api/users/me.ts
+++ b/src/shared/api/users/me.ts
@@ -1,0 +1,11 @@
+import client from '@/shared/api/client';
+
+export interface GetMyUserResponse {
+  id: number;
+}
+
+export async function getMyUser(): Promise<GetMyUserResponse> {
+  const response = await client.get<GetMyUserResponse>('/api/v1/users/me');
+
+  return response.data;
+}

--- a/src/shared/api/users/meQueries.ts
+++ b/src/shared/api/users/meQueries.ts
@@ -1,0 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getMyUser } from '@/shared/api/users/me';
+
+export const myUserQueryOptions = () =>
+  queryOptions({
+    queryKey: ['myUser'],
+    queryFn: getMyUser,
+  });


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 상세에서 작성자 본인만 게시글을 수정할 수 있도록 `PATCH /api/v1/posts/{postId}`를 연결했습니다.
- 기존 `CreatePostModal`을 create / edit 공용 모달로 확장해 게시글 작성과 수정 흐름을 재사용하도록 정리했습니다.
- 수정 성공 후 현재 선택된 글을 유지한 채 목록과 상세를 최신화하고, 필요하면 수정된 카테고리 기준으로 필터를 맞추도록 연결했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/posts/posts.ts`에 `updatePost(postId, payload)`와 수정 요청 타입 추가
- `src/shared/api/posts/index.ts` export 정리
- `src/shared/api/users/me.ts`, `src/shared/api/users/meQueries.ts` 추가
- `src/pages/main/ui/board/CreatePostModal.tsx`를 생성 / 수정 공용 모달로 확장
- `src/pages/main/ui/board/MainBoardSection.tsx`에 작성자 전용 `게시글 수정` 버튼, 현재 사용자 id 비교, 수정 후 선택 / 필터 동기화 추가
- `src/pages/main/ui/layout/MainPage.tsx`, `src/pages/main/ui/layout/MainTabSection.tsx`, `src/pages/main/ui/board/types.ts`에 보드 post sync 흐름 정리

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 수정 연결과 수정 성공 후 상태 동기화 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 권한 판단은 auth store가 아니라 새 `/api/v1/users/me` 조회와 게시글 상세 `userId` 비교로 처리합니다.
- 성공 / 실패 피드백은 BOARD 공용 메시지 대신 모달 내부에서 처리합니다.
- 수정 후 현재 필터에 글이 보이지 않는 경우 수정된 카테고리 기준으로 필터를 맞춘 뒤 같은 글을 유지합니다.
- 댓글 / 좋아요 / 삭제 액션은 후속 이슈에서 다룹니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #81
