### PR TITLE
feat: (#82) 게시글 삭제 연결

### DIFF
--- a/src/pages/main/ui/board/DeletePostConfirmModal.tsx
+++ b/src/pages/main/ui/board/DeletePostConfirmModal.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+
+interface DeletePostConfirmModalProps {
+  isOpen: boolean;
+  isPending: boolean;
+  errorMessage: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const DeletePostConfirmModal = ({
+  isOpen,
+  isPending,
+  errorMessage,
+  onClose,
+  onConfirm,
+}: DeletePostConfirmModalProps) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialogElement = dialogRef.current;
+
+    if (!dialogElement) {
+      return;
+    }
+
+    if (isOpen && !dialogElement.open) {
+      dialogElement.showModal();
+      return;
+    }
+
+    if (!isOpen && dialogElement.open) {
+      dialogElement.close();
+    }
+  }, [isOpen]);
+
+  const handleDialogClick = (event: React.MouseEvent<HTMLDialogElement>) => {
+    if (event.target === dialogRef.current && !isPending) {
+      onClose();
+    }
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      onClick={handleDialogClick}
+      className="backdrop:bg-slate-950/50 w-full max-w-lg rounded-[32px] bg-white p-0 text-left shadow-[0_24px_80px_rgba(15,23,42,0.22)] backdrop:backdrop-blur-[2px]"
+    >
+      <div className="p-6 md:p-7">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-rose-50 text-rose-500">
+              <AlertTriangle className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-rose-500">게시글 삭제</p>
+              <h2 className="mt-1 text-[24px] font-bold tracking-[-0.03em] text-slate-900">
+                이 게시글을 삭제할까요?
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-slate-500">
+                삭제 후 되돌릴 수 없어요.
+              </p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-100 text-slate-500 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {errorMessage ? (
+          <p className="mt-5 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-600">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col-reverse gap-3 md:flex-row md:justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            className="rounded-2xl border border-slate-200 px-5 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isPending}
+            className="rounded-2xl bg-rose-500 px-5 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(244,63,94,0.25)] transition hover:bg-rose-600 disabled:cursor-not-allowed disabled:bg-rose-300"
+          >
+            {isPending ? '삭제 중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+};
+
+export default DeletePostConfirmModal;

--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -1,7 +1,9 @@
-import { Heart, MessageSquareText, PencilLine } from 'lucide-react';
+import { Heart, MessageSquareText, PencilLine, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  deletePost,
+  type GetPostsResponse,
   postQueries,
   type PostDetailResponse,
   type PostListItemResponse,
@@ -17,6 +19,7 @@ import {
   type MainBoardCategoryFilter,
 } from './board.constants';
 import CreatePostModal, { type CreatePostFormValues } from './CreatePostModal';
+import DeletePostConfirmModal from './DeletePostConfirmModal';
 
 const BOARD_LIST_DEFAULT_PAGE = 1;
 const BOARD_LIST_DEFAULT_SIZE = 10;
@@ -118,6 +121,20 @@ const toEditPostFormValues = (post: MainBoardPost): CreatePostFormValues => ({
   content: post.content,
 });
 
+const isPostListData = (value: unknown): value is GetPostsResponse =>
+  typeof value === 'object' &&
+  value !== null &&
+  'items' in value &&
+  Array.isArray((value as { items?: unknown }).items);
+
+const isInfinitePostListData = (
+  value: unknown,
+): value is { pages: GetPostsResponse[]; pageParams: unknown[] } =>
+  typeof value === 'object' &&
+  value !== null &&
+  'pages' in value &&
+  Array.isArray((value as { pages?: unknown }).pages);
+
 interface MainBoardSectionProps {
   postSyncRequest: MainBoardPostSyncRequest | null;
   onPostSyncHandled: () => void;
@@ -129,10 +146,13 @@ const MainBoardSection = ({
   onPostSyncHandled,
   onRequireLogin,
 }: MainBoardSectionProps) => {
+  const queryClient = useQueryClient();
   const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<MainBoardCategoryFilter>('ALL');
   const [pendingSyncedPostId, setPendingSyncedPostId] = useState<number | null>(null);
   const [isEditPostModalOpen, setIsEditPostModalOpen] = useState(false);
+  const [isDeleteConfirmModalOpen, setIsDeleteConfirmModalOpen] = useState(false);
+  const [deleteErrorMessage, setDeleteErrorMessage] = useState('');
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const categoryId =
     selectedCategory === 'ALL' ? undefined : boardCategoryIdMap[selectedCategory];
@@ -175,6 +195,9 @@ const MainBoardSection = ({
   const canEditSelectedPost =
     selectedBoardPostDetailData !== undefined && myUserData?.id === selectedBoardPostDetailData.userId;
   const hasLoadedPosts = data !== undefined;
+  const deletePostMutation = useMutation({
+    mutationFn: deletePost,
+  });
 
   useEffect(() => {
     if (!postSyncRequest) {
@@ -248,6 +271,89 @@ const MainBoardSection = ({
       observer.disconnect();
     };
   }, [fetchNextPage, hasNextPage, isError, isFetchingNextPage, isLoading]);
+
+  const handleDeleteConfirmClose = () => {
+    if (deletePostMutation.isPending) {
+      return;
+    }
+
+    setDeleteErrorMessage('');
+    setIsDeleteConfirmModalOpen(false);
+  };
+
+  const handleDeletePost = async () => {
+    if (!selectedBoardPostDetail) {
+      return;
+    }
+
+    setDeleteErrorMessage('');
+
+    try {
+      await deletePostMutation.mutateAsync(selectedBoardPostDetail.id);
+
+      const nextBoardPost = boardPosts.find(
+        (boardPost) => boardPost.id !== selectedBoardPostDetail.id,
+      );
+
+      queryClient.setQueriesData({ queryKey: postQueries.lists() }, (currentData) => {
+        if (isPostListData(currentData)) {
+          return {
+            ...currentData,
+            items: currentData.items.filter((item) => item.id !== selectedBoardPostDetail.id),
+          };
+        }
+
+        if (isInfinitePostListData(currentData)) {
+          return {
+            ...currentData,
+            pages: currentData.pages.map((page) => ({
+              ...page,
+              items: page.items.filter((item) => item.id !== selectedBoardPostDetail.id),
+            })),
+          };
+        }
+
+        return currentData;
+      });
+
+      setIsDeleteConfirmModalOpen(false);
+      setIsEditPostModalOpen(false);
+      setDeleteErrorMessage('');
+      setPendingSyncedPostId(nextBoardPost?.id ?? null);
+      setSelectedBoardPostId(nextBoardPost?.id ?? null);
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: postQueries.lists() }),
+        queryClient.invalidateQueries({ queryKey: postQueries.details() }),
+      ]);
+    } catch (error) {
+      if (typeof error === 'object' && error !== null && 'response' in error) {
+        const axiosError = error as {
+          response?: {
+            status?: number;
+          };
+        };
+
+        if (axiosError.response?.status === 401) {
+          setDeleteErrorMessage('로그인 후 게시글을 삭제할 수 있어요.');
+          onRequireLogin();
+          return;
+        }
+
+        if (axiosError.response?.status === 403) {
+          setDeleteErrorMessage('게시글을 삭제할 권한이 없어요.');
+          return;
+        }
+
+        if (axiosError.response?.status === 404) {
+          setDeleteErrorMessage('게시글을 찾을 수 없어요.');
+          return;
+        }
+      }
+
+      setDeleteErrorMessage('게시글을 삭제하지 못했어요. 잠시 후 다시 시도해주세요.');
+    }
+  };
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -411,14 +517,24 @@ const MainBoardSection = ({
                   </div>
 
                   {canEditSelectedPost ? (
-                    <button
-                      type="button"
-                      onClick={() => setIsEditPostModalOpen(true)}
-                      className="inline-flex items-center gap-1.5 rounded-2xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
-                    >
-                      <PencilLine className="h-4 w-4" />
-                      게시글 수정
-                    </button>
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => setIsEditPostModalOpen(true)}
+                        className="inline-flex items-center gap-1.5 rounded-2xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
+                      >
+                        <PencilLine className="h-4 w-4" />
+                        게시글 수정
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setIsDeleteConfirmModalOpen(true)}
+                        className="inline-flex items-center gap-1.5 rounded-2xl border border-rose-200 px-3 py-2 text-sm font-semibold text-rose-600 transition hover:bg-rose-50"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        게시글 삭제
+                      </button>
+                    </>
                   ) : null}
                 </div>
               </div>
@@ -464,6 +580,16 @@ const MainBoardSection = ({
           }}
         />
       ) : null}
+
+      <DeletePostConfirmModal
+        isOpen={isDeleteConfirmModalOpen}
+        isPending={deletePostMutation.isPending}
+        errorMessage={deleteErrorMessage}
+        onClose={handleDeleteConfirmClose}
+        onConfirm={() => {
+          void handleDeletePost();
+        }}
+      />
     </section>
   );
 };

--- a/src/shared/api/posts/index.ts
+++ b/src/shared/api/posts/index.ts
@@ -9,5 +9,5 @@ export type {
   PostListUserResponse,
   UpdatePostRequest,
 } from './posts';
-export { createPost, getPostDetail, getPosts, updatePost } from './posts';
+export { createPost, deletePost, getPostDetail, getPosts, updatePost } from './posts';
 export { postQueries } from './postsQueries';

--- a/src/shared/api/posts/posts.ts
+++ b/src/shared/api/posts/posts.ts
@@ -104,6 +104,10 @@ export async function updatePost(
   return response.data;
 }
 
+export async function deletePost(postId: number): Promise<void> {
+  await client.delete(`/api/v1/posts/${postId}`);
+}
+
 export async function getPostDetail(postId: number): Promise<PostDetailResponse> {
   const response = await client.get<PostDetailResponse>(`/api/v1/posts/${postId}`);
 


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 상세에서 작성자 본인만 게시글을 삭제할 수 있도록 `DELETE /api/v1/posts/{postId}`를 연결했습니다.
- 삭제 전 간단 확인 모달을 추가해 실수 삭제를 막고, 삭제 요청은 확인 이후에만 진행되도록 정리했습니다.
- 삭제 성공 후 현재 필터를 유지한 채 목록을 갱신하고, 남아 있는 첫 번째 글을 자동 선택하도록 맞췄습니다. 현재 필터 결과가 비면 상세는 닫히도록 처리했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/posts/posts.ts`에 `deletePost(postId)` 추가
- `src/shared/api/posts/index.ts` export 정리
- `src/pages/main/ui/board/DeletePostConfirmModal.tsx` 추가
- `src/pages/main/ui/board/MainBoardSection.tsx`에 작성자 전용 `게시글 삭제` 버튼, 확인 모달, 삭제 후 목록 캐시 정리 및 선택 상태 동기화 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 삭제 연결과 삭제 후 상태 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 권한 판단은 기존 `/api/v1/users/me` 조회와 게시글 상세 `userId` 비교를 재사용합니다.
- 성공 / 실패 피드백은 BOARD 공용 메시지 대신 삭제 모달 내부에서 처리합니다.
- 삭제 성공 후 현재 필터를 유지한 채 남은 첫 번째 글을 선택하고, 필터 결과가 비면 상세를 닫습니다.
- 댓글 / 좋아요 액션은 후속 이슈에서 다룹니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #82
