### PR TITLE
feat: (#83) 게시글 좋아요 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -4,6 +4,7 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tansta
 import {
   deletePost,
   type GetPostsResponse,
+  likePost,
   postQueries,
   type PostDetailResponse,
   type PostListItemResponse,
@@ -153,6 +154,7 @@ const MainBoardSection = ({
   const [isEditPostModalOpen, setIsEditPostModalOpen] = useState(false);
   const [isDeleteConfirmModalOpen, setIsDeleteConfirmModalOpen] = useState(false);
   const [deleteErrorMessage, setDeleteErrorMessage] = useState('');
+  const [likeErrorMessage, setLikeErrorMessage] = useState('');
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const categoryId =
     selectedCategory === 'ALL' ? undefined : boardCategoryIdMap[selectedCategory];
@@ -192,9 +194,13 @@ const MainBoardSection = ({
     selectedBoardPostDetailData && selectedBoardPost
       ? toMainBoardPostDetail(selectedBoardPostDetailData, selectedBoardPost.author)
       : null;
+  const isSelectedBoardPostLiked = selectedBoardPostDetailData?.liked ?? false;
   const canEditSelectedPost =
     selectedBoardPostDetailData !== undefined && myUserData?.id === selectedBoardPostDetailData.userId;
   const hasLoadedPosts = data !== undefined;
+  const likePostMutation = useMutation({
+    mutationFn: likePost,
+  });
   const deletePostMutation = useMutation({
     mutationFn: deletePost,
   });
@@ -249,6 +255,10 @@ const MainBoardSection = ({
   }, [boardPosts, isFetching, pendingSyncedPostId, selectedBoardPostId]);
 
   useEffect(() => {
+    setLikeErrorMessage('');
+  }, [selectedBoardPostId]);
+
+  useEffect(() => {
     const target = loadMoreRef.current;
 
     if (!target || isLoading || isError || !hasNextPage) {
@@ -279,6 +289,89 @@ const MainBoardSection = ({
 
     setDeleteErrorMessage('');
     setIsDeleteConfirmModalOpen(false);
+  };
+
+  const handleLikePost = async () => {
+    if (!selectedBoardPostDetailData) {
+      return;
+    }
+
+    setLikeErrorMessage('');
+
+    try {
+      const response = await likePostMutation.mutateAsync(selectedBoardPostDetailData.id);
+
+      queryClient.setQueryData<PostDetailResponse>(
+        postQueries.detail(selectedBoardPostDetailData.id).queryKey,
+        (currentData) => {
+          if (!currentData) {
+            return currentData;
+          }
+
+          return {
+            ...currentData,
+            liked: response.liked,
+            likeCount: response.likeCount,
+          };
+        },
+      );
+
+      queryClient.setQueriesData({ queryKey: postQueries.lists() }, (currentData) => {
+        if (isPostListData(currentData)) {
+          return {
+            ...currentData,
+            items: currentData.items.map((item) =>
+              item.id === selectedBoardPostDetailData.id
+                ? {
+                    ...item,
+                    likeCount: response.likeCount,
+                  }
+                : item,
+            ),
+          };
+        }
+
+        if (isInfinitePostListData(currentData)) {
+          return {
+            ...currentData,
+            pages: currentData.pages.map((page) => ({
+              ...page,
+              items: page.items.map((item) =>
+                item.id === selectedBoardPostDetailData.id
+                  ? {
+                      ...item,
+                      likeCount: response.likeCount,
+                    }
+                  : item,
+              ),
+            })),
+          };
+        }
+
+        return currentData;
+      });
+    } catch (error) {
+      if (typeof error === 'object' && error !== null && 'response' in error) {
+        const axiosError = error as {
+          response?: {
+            status?: number;
+          };
+        };
+
+        if (axiosError.response?.status === 401) {
+          setLikeErrorMessage('로그인 후 게시글을 좋아요할 수 있어요.');
+          onRequireLogin();
+          return;
+        }
+
+        if (axiosError.response?.status === 404) {
+          setLikeErrorMessage('게시글을 찾을 수 없어요.');
+          return;
+        }
+      }
+
+      setLikeErrorMessage('좋아요를 반영하지 못했어요. 잠시 후 다시 시도해주세요.');
+    }
   };
 
   const handleDeletePost = async () => {
@@ -506,10 +599,23 @@ const MainBoardSection = ({
 
                 <div className="flex items-center gap-3">
                   <div className="flex items-center gap-3 text-sm text-slate-500">
-                    <span className="inline-flex items-center gap-1.5">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void handleLikePost();
+                      }}
+                      disabled={likePostMutation.isPending}
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm font-semibold transition',
+                        isSelectedBoardPostLiked
+                          ? 'bg-rose-50 text-rose-600'
+                          : 'text-slate-500 hover:bg-slate-50 hover:text-slate-700',
+                        likePostMutation.isPending && 'cursor-not-allowed opacity-60',
+                      )}
+                    >
                       <Heart className="h-4 w-4 text-rose-400" />
                       {selectedBoardPostDetail.likedCount}
-                    </span>
+                    </button>
                     <span className="inline-flex items-center gap-1.5">
                       <MessageSquareText className="h-4 w-4 text-indigo-500" />
                       {selectedBoardPostDetail.commentCount}
@@ -549,6 +655,10 @@ const MainBoardSection = ({
               <div className="mt-4 text-xs font-medium text-slate-400">
                 조회 {selectedBoardPostDetailData?.viewCount ?? 0}
               </div>
+
+              {likeErrorMessage ? (
+                <p className="mt-4 text-sm font-medium text-rose-500">{likeErrorMessage}</p>
+              ) : null}
 
               <div className="mt-6 whitespace-pre-line rounded-[24px] bg-slate-50 px-5 py-5 text-sm leading-7 text-slate-600">
                 {selectedBoardPostDetail.content}

--- a/src/shared/api/posts/index.ts
+++ b/src/shared/api/posts/index.ts
@@ -3,11 +3,12 @@ export type {
   CreatePostResponse,
   GetPostsParams,
   GetPostsResponse,
+  LikePostResponse,
   PostDetailResponse,
   PostListItemResponse,
   PostListPaginationResponse,
   PostListUserResponse,
   UpdatePostRequest,
 } from './posts';
-export { createPost, deletePost, getPostDetail, getPosts, updatePost } from './posts';
+export { createPost, deletePost, getPostDetail, getPosts, likePost, updatePost } from './posts';
 export { postQueries } from './postsQueries';

--- a/src/shared/api/posts/posts.ts
+++ b/src/shared/api/posts/posts.ts
@@ -72,9 +72,15 @@ export interface PostDetailResponse {
   title: string;
   content: string;
   viewCount?: number | null;
+  liked?: boolean | null;
   likeCount?: number | null;
   commentCount?: number | null;
   createdAt: string;
+}
+
+export interface LikePostResponse {
+  liked: boolean;
+  likeCount: number;
 }
 
 export async function getPosts(params: GetPostsParams = {}): Promise<GetPostsResponse> {
@@ -91,6 +97,12 @@ export async function getPosts(params: GetPostsParams = {}): Promise<GetPostsRes
 
 export async function createPost(payload: CreatePostRequest): Promise<CreatePostResponse> {
   const response = await client.post<CreatePostResponse>('/api/v1/posts', payload);
+
+  return response.data;
+}
+
+export async function likePost(postId: number): Promise<LikePostResponse> {
+  const response = await client.post<LikePostResponse>(`/api/v1/posts/${postId}/like`);
 
   return response.data;
 }


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 상세에서 `POST /api/v1/posts/{postId}/like` 기반 게시글 좋아요 토글을 연결했습니다.
- 좋아요 액션은 상세 카드에서만 가능하도록 두고, 목록 카드는 좋아요 수 표시만 유지했습니다.
- 좋아요 성공 시 상세의 `liked` / `likeCount`와 목록의 `likeCount`를 함께 갱신하도록 정리했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/posts/posts.ts`에 `likePost(postId)`와 좋아요 응답 타입 추가
- `src/shared/api/posts/index.ts` export 정리
- `src/pages/main/ui/board/MainBoardSection.tsx`에 상세 전용 좋아요 버튼, `liked` 상태 스타일, 좋아요 에러 처리, 상세 / 목록 캐시 동기화 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 좋아요 연결과 상세 / 목록 like count 동기화 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 좋아요 액션은 상세 카드에서만 제공하고, 목록 카드는 count 표시만 유지합니다.
- 좋아요 성공 시 상세 캐시의 `liked` / `likeCount`와 목록 캐시의 `likeCount`를 함께 갱신합니다.
- `401`은 `로그인 후 게시글을 좋아요할 수 있어요.` 문구와 함께 로그인 모달을 열도록 연결했습니다.
- `404 / 기타` 실패는 상세 액션 영역에서만 안내합니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #83
