### PR TITLE
feat: (#89) 게시글 싫어요 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -1,8 +1,9 @@
-import { Heart, MessageSquareText, PencilLine, Trash2 } from 'lucide-react';
+import { Heart, MessageSquareText, PencilLine, ThumbsDown, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   deletePost,
+  dislikePost,
   type GetPostsResponse,
   likePost,
   postQueries,
@@ -154,7 +155,7 @@ const MainBoardSection = ({
   const [isEditPostModalOpen, setIsEditPostModalOpen] = useState(false);
   const [isDeleteConfirmModalOpen, setIsDeleteConfirmModalOpen] = useState(false);
   const [deleteErrorMessage, setDeleteErrorMessage] = useState('');
-  const [likeErrorMessage, setLikeErrorMessage] = useState('');
+  const [reactionErrorMessage, setReactionErrorMessage] = useState('');
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const categoryId =
     selectedCategory === 'ALL' ? undefined : boardCategoryIdMap[selectedCategory];
@@ -195,11 +196,15 @@ const MainBoardSection = ({
       ? toMainBoardPostDetail(selectedBoardPostDetailData, selectedBoardPost.author)
       : null;
   const isSelectedBoardPostLiked = selectedBoardPostDetailData?.liked ?? false;
+  const isSelectedBoardPostDisliked = selectedBoardPostDetailData?.disliked ?? false;
   const canEditSelectedPost =
     selectedBoardPostDetailData !== undefined && myUserData?.id === selectedBoardPostDetailData.userId;
   const hasLoadedPosts = data !== undefined;
   const likePostMutation = useMutation({
     mutationFn: likePost,
+  });
+  const dislikePostMutation = useMutation({
+    mutationFn: dislikePost,
   });
   const deletePostMutation = useMutation({
     mutationFn: deletePost,
@@ -255,7 +260,7 @@ const MainBoardSection = ({
   }, [boardPosts, isFetching, pendingSyncedPostId, selectedBoardPostId]);
 
   useEffect(() => {
-    setLikeErrorMessage('');
+    setReactionErrorMessage('');
   }, [selectedBoardPostId]);
 
   useEffect(() => {
@@ -296,10 +301,15 @@ const MainBoardSection = ({
       return;
     }
 
-    setLikeErrorMessage('');
+    setReactionErrorMessage('');
+
+    const wasDisliked = selectedBoardPostDetailData.disliked ?? false;
+    const currentDislikeCount = selectedBoardPostDetailData.dislikeCount ?? 0;
 
     try {
       const response = await likePostMutation.mutateAsync(selectedBoardPostDetailData.id);
+      const nextDislikeCount =
+        response.liked && wasDisliked ? Math.max(0, currentDislikeCount - 1) : currentDislikeCount;
 
       queryClient.setQueryData<PostDetailResponse>(
         postQueries.detail(selectedBoardPostDetailData.id).queryKey,
@@ -311,7 +321,9 @@ const MainBoardSection = ({
           return {
             ...currentData,
             liked: response.liked,
+            disliked: response.liked && wasDisliked ? false : currentData.disliked,
             likeCount: response.likeCount,
+            dislikeCount: nextDislikeCount,
           };
         },
       );
@@ -325,6 +337,7 @@ const MainBoardSection = ({
                 ? {
                     ...item,
                     likeCount: response.likeCount,
+                    dislikeCount: nextDislikeCount,
                   }
                 : item,
             ),
@@ -341,6 +354,7 @@ const MainBoardSection = ({
                   ? {
                       ...item,
                       likeCount: response.likeCount,
+                      dislikeCount: nextDislikeCount,
                     }
                   : item,
               ),
@@ -359,18 +373,110 @@ const MainBoardSection = ({
         };
 
         if (axiosError.response?.status === 401) {
-          setLikeErrorMessage('로그인 후 게시글을 좋아요할 수 있어요.');
+          setReactionErrorMessage('로그인 후 게시글을 좋아요할 수 있어요.');
           onRequireLogin();
           return;
         }
 
         if (axiosError.response?.status === 404) {
-          setLikeErrorMessage('게시글을 찾을 수 없어요.');
+          setReactionErrorMessage('게시글을 찾을 수 없어요.');
           return;
         }
       }
 
-      setLikeErrorMessage('좋아요를 반영하지 못했어요. 잠시 후 다시 시도해주세요.');
+      setReactionErrorMessage('좋아요를 반영하지 못했어요. 잠시 후 다시 시도해주세요.');
+    }
+  };
+
+  const handleDislikePost = async () => {
+    if (!selectedBoardPostDetailData) {
+      return;
+    }
+
+    setReactionErrorMessage('');
+
+    const wasLiked = selectedBoardPostDetailData.liked ?? false;
+    const currentLikeCount = selectedBoardPostDetailData.likeCount ?? 0;
+
+    try {
+      const response = await dislikePostMutation.mutateAsync(selectedBoardPostDetailData.id);
+      const nextLikeCount =
+        response.disliked && wasLiked ? Math.max(0, currentLikeCount - 1) : currentLikeCount;
+
+      queryClient.setQueryData<PostDetailResponse>(
+        postQueries.detail(selectedBoardPostDetailData.id).queryKey,
+        (currentData) => {
+          if (!currentData) {
+            return currentData;
+          }
+
+          return {
+            ...currentData,
+            liked: response.disliked && wasLiked ? false : currentData.liked,
+            disliked: response.disliked,
+            likeCount: nextLikeCount,
+            dislikeCount: response.dislikeCount,
+          };
+        },
+      );
+
+      queryClient.setQueriesData({ queryKey: postQueries.lists() }, (currentData) => {
+        if (isPostListData(currentData)) {
+          return {
+            ...currentData,
+            items: currentData.items.map((item) =>
+              item.id === selectedBoardPostDetailData.id
+                ? {
+                    ...item,
+                    likeCount: nextLikeCount,
+                    dislikeCount: response.dislikeCount,
+                  }
+                : item,
+            ),
+          };
+        }
+
+        if (isInfinitePostListData(currentData)) {
+          return {
+            ...currentData,
+            pages: currentData.pages.map((page) => ({
+              ...page,
+              items: page.items.map((item) =>
+                item.id === selectedBoardPostDetailData.id
+                  ? {
+                      ...item,
+                      likeCount: nextLikeCount,
+                      dislikeCount: response.dislikeCount,
+                    }
+                  : item,
+              ),
+            })),
+          };
+        }
+
+        return currentData;
+      });
+    } catch (error) {
+      if (typeof error === 'object' && error !== null && 'response' in error) {
+        const axiosError = error as {
+          response?: {
+            status?: number;
+          };
+        };
+
+        if (axiosError.response?.status === 401) {
+          setReactionErrorMessage('로그인 후 게시글을 싫어요할 수 있어요.');
+          onRequireLogin();
+          return;
+        }
+
+        if (axiosError.response?.status === 404) {
+          setReactionErrorMessage('게시글을 찾을 수 없어요.');
+          return;
+        }
+      }
+
+      setReactionErrorMessage('싫어요를 반영하지 못했어요. 잠시 후 다시 시도해주세요.');
     }
   };
 
@@ -604,17 +710,36 @@ const MainBoardSection = ({
                       onClick={() => {
                         void handleLikePost();
                       }}
-                      disabled={likePostMutation.isPending}
+                      disabled={likePostMutation.isPending || dislikePostMutation.isPending}
                       className={cn(
                         'inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm font-semibold transition',
                         isSelectedBoardPostLiked
                           ? 'bg-rose-50 text-rose-600'
                           : 'text-slate-500 hover:bg-slate-50 hover:text-slate-700',
-                        likePostMutation.isPending && 'cursor-not-allowed opacity-60',
+                        (likePostMutation.isPending || dislikePostMutation.isPending) &&
+                          'cursor-not-allowed opacity-60',
                       )}
                     >
                       <Heart className="h-4 w-4 text-rose-400" />
                       {selectedBoardPostDetail.likedCount}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void handleDislikePost();
+                      }}
+                      disabled={likePostMutation.isPending || dislikePostMutation.isPending}
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded-2xl px-3 py-2 text-sm font-semibold transition',
+                        isSelectedBoardPostDisliked
+                          ? 'bg-slate-200 text-slate-700'
+                          : 'text-slate-500 hover:bg-slate-50 hover:text-slate-700',
+                        (likePostMutation.isPending || dislikePostMutation.isPending) &&
+                          'cursor-not-allowed opacity-60',
+                      )}
+                    >
+                      <ThumbsDown className="h-4 w-4 text-slate-500" />
+                      {selectedBoardPostDetailData?.dislikeCount ?? 0}
                     </button>
                     <span className="inline-flex items-center gap-1.5">
                       <MessageSquareText className="h-4 w-4 text-indigo-500" />
@@ -656,8 +781,8 @@ const MainBoardSection = ({
                 조회 {selectedBoardPostDetailData?.viewCount ?? 0}
               </div>
 
-              {likeErrorMessage ? (
-                <p className="mt-4 text-sm font-medium text-rose-500">{likeErrorMessage}</p>
+              {reactionErrorMessage ? (
+                <p className="mt-4 text-sm font-medium text-rose-500">{reactionErrorMessage}</p>
               ) : null}
 
               <div className="mt-6 whitespace-pre-line rounded-[24px] bg-slate-50 px-5 py-5 text-sm leading-7 text-slate-600">

--- a/src/shared/api/posts/index.ts
+++ b/src/shared/api/posts/index.ts
@@ -1,6 +1,7 @@
 export type {
   CreatePostRequest,
   CreatePostResponse,
+  DislikePostResponse,
   GetPostsParams,
   GetPostsResponse,
   LikePostResponse,
@@ -10,5 +11,5 @@ export type {
   PostListUserResponse,
   UpdatePostRequest,
 } from './posts';
-export { createPost, deletePost, getPostDetail, getPosts, likePost, updatePost } from './posts';
+export { createPost, deletePost, dislikePost, getPostDetail, getPosts, likePost, updatePost } from './posts';
 export { postQueries } from './postsQueries';

--- a/src/shared/api/posts/posts.ts
+++ b/src/shared/api/posts/posts.ts
@@ -20,6 +20,7 @@ export interface PostListItemResponse {
   summary?: string | null;
   content?: string | null;
   likeCount?: number | null;
+  dislikeCount?: number | null;
   commentCount?: number | null;
   createdAt: string;
   author?: string | null;
@@ -73,7 +74,9 @@ export interface PostDetailResponse {
   content: string;
   viewCount?: number | null;
   liked?: boolean | null;
+  disliked?: boolean | null;
   likeCount?: number | null;
+  dislikeCount?: number | null;
   commentCount?: number | null;
   createdAt: string;
 }
@@ -81,6 +84,11 @@ export interface PostDetailResponse {
 export interface LikePostResponse {
   liked: boolean;
   likeCount: number;
+}
+
+export interface DislikePostResponse {
+  disliked: boolean;
+  dislikeCount: number;
 }
 
 export async function getPosts(params: GetPostsParams = {}): Promise<GetPostsResponse> {
@@ -103,6 +111,12 @@ export async function createPost(payload: CreatePostRequest): Promise<CreatePost
 
 export async function likePost(postId: number): Promise<LikePostResponse> {
   const response = await client.post<LikePostResponse>(`/api/v1/posts/${postId}/like`);
+
+  return response.data;
+}
+
+export async function dislikePost(postId: number): Promise<DislikePostResponse> {
+  const response = await client.post<DislikePostResponse>(`/api/v1/posts/${postId}/dislike`);
 
   return response.data;
 }


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 상세에서 `POST /api/v1/posts/{postId}/dislike` 기반 게시글 싫어요 토글을 연결했습니다.
- 싫어요 액션은 상세 카드에서만 가능하도록 두고, 목록 카드는 기존처럼 좋아요 수와 댓글 수 표시만 유지했습니다.
- 싫어요 성공 시 상세의 `disliked` / `dislikeCount`를 반영하고, 좋아요와 배타적으로 동작하도록 `liked` / `likeCount`와 목록 캐시까지 함께 정리했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/posts/posts.ts`에 `dislikePost(postId)`와 `disliked / dislikeCount` 관련 타입 추가
- `src/shared/api/posts/index.ts` export 정리
- `src/pages/main/ui/board/MainBoardSection.tsx`에 상세 전용 싫어요 버튼, `disliked` 상태 스타일, 반응 에러 처리, 좋아요 / 싫어요 배타 캐시 동기화 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 싫어요 연결과 좋아요 / 싫어요 배타 상태 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 공식 frontend API 명세에는 게시글 dislike가 아직 없어, 이번 PR은 `POST /api/v1/posts/{postId}/dislike` 가정 계약 기준으로 구현했습니다.
- 싫어요 액션은 상세 카드에서만 제공하고, 목록 카드는 싫어요 UI를 추가하지 않았습니다.
- 싫어요 성공 시 상세 캐시의 `disliked / dislikeCount`와 목록 캐시의 `dislikeCount`를 갱신하고, 기존 liked 상태였다면 `liked / likeCount`도 함께 정리합니다.
- `401`은 `로그인 후 게시글을 싫어요할 수 있어요.` 문구와 함께 로그인 모달을 열도록 연결했습니다.
- `404 / 기타` 실패는 상세 액션 영역에서만 안내합니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #89
