### PR TITLE
feat: (#84) 댓글 목록 조회 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -1,9 +1,15 @@
 import { Heart, MessageSquareText, Pencil, SendHorizonal, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { isAuthenticated } from '@/app/authSessionStore';
+import { commentQueries, type CommentListItemResponse } from '@/shared/api/comments';
+import { myUserQueryOptions } from '@/shared/api/users/meQueries';
 import { cn } from '@/shared/lib/utils';
-
-import { mockBoardComments } from './mockBoardComments';
+import type { MainBoardComment } from './types';
 import { mockBoardPosts } from './mockBoardPosts';
+
+const COMMENTS_LIST_DEFAULT_PAGE = 1;
+const COMMENTS_LIST_DEFAULT_SIZE = 20;
 
 const categoryStyleMap = {
   FREE: 'bg-slate-100 text-slate-600',
@@ -32,6 +38,32 @@ const formatRelativeCreatedAt = (createdAt: string) => {
   return `${diffDays}일 전`;
 };
 
+const toBoardCommentAuthor = (comment: CommentListItemResponse) =>
+  comment.author?.trim() ||
+  comment.authorNickname?.trim() ||
+  comment.userNickname?.trim() ||
+  comment.nickname?.trim() ||
+  comment.user?.nickname?.trim() ||
+  '익명 사용자';
+
+const toMainBoardComment = (
+  comment: CommentListItemResponse,
+  postId: number,
+  currentUserId: number | null,
+): MainBoardComment => ({
+  id: comment.id,
+  postId: comment.postId ?? postId,
+  author: toBoardCommentAuthor(comment),
+  content: comment.content,
+  likedCount: comment.likeCount ?? 0,
+  createdAt: comment.createdAt,
+  isMine:
+    typeof comment.isMine === 'boolean'
+      ? comment.isMine
+      : currentUserId !== null &&
+        (comment.userId === currentUserId || comment.authorId === currentUserId),
+});
+
 const MainBoardSection = () => {
   const initialSelectedBoardPostId = mockBoardPosts[0]?.id ?? null;
   const [selectedBoardPostId, setSelectedBoardPostId] = useState<number | null>(
@@ -40,8 +72,32 @@ const MainBoardSection = () => {
   const selectedBoardPost = mockBoardPosts.find(
     (mockBoardPost) => mockBoardPost.id === selectedBoardPostId,
   );
-  const selectedBoardComments = mockBoardComments.filter(
-    (mockBoardComment) => mockBoardComment.postId === selectedBoardPostId,
+  const isLoggedIn = isAuthenticated();
+  const { data: currentUser } = useQuery({
+    ...myUserQueryOptions(),
+    enabled: isLoggedIn,
+  });
+  const {
+    data: commentsData,
+    isLoading: isCommentsLoading,
+    isError: isCommentsError,
+    error: commentsError,
+  } = useQuery({
+    ...commentQueries.list(selectedBoardPostId ?? 0, {
+      page: COMMENTS_LIST_DEFAULT_PAGE,
+      size: COMMENTS_LIST_DEFAULT_SIZE,
+    }),
+    enabled: selectedBoardPostId !== null,
+  });
+
+  const selectedBoardComments = useMemo(
+    () =>
+      selectedBoardPostId === null
+        ? []
+        : (commentsData?.items ?? []).map((comment) =>
+            toMainBoardComment(comment, selectedBoardPostId, currentUser?.id ?? null),
+          ),
+    [commentsData?.items, currentUser?.id, selectedBoardPostId],
   );
 
   return (
@@ -128,24 +184,28 @@ const MainBoardSection = () => {
           <section className="mt-8">
             <div className="flex items-center justify-between gap-3">
               <h4 className="text-lg font-bold tracking-[-0.03em] text-slate-900">
-                댓글 {selectedBoardComments.length}
+                댓글 {selectedBoardPost.commentCount}
               </h4>
-              <span className="text-sm text-slate-400">mock UI</span>
+              <span className="text-sm text-slate-400">목록 조회 연결</span>
             </div>
 
             <div className="mt-4 rounded-[24px] border border-slate-200 bg-slate-50 p-4">
               <label className="block">
                 <span className="text-sm font-semibold text-slate-700">댓글 작성</span>
                 <textarea
-                  placeholder="댓글을 입력해보세요"
-                  className="mt-3 min-h-[110px] w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+                  disabled
+                  placeholder="댓글 작성은 다음 이슈에서 연결 예정이에요."
+                  className="mt-3 min-h-[110px] w-full cursor-not-allowed rounded-2xl border border-slate-200 bg-slate-100 px-4 py-3 text-sm text-slate-500 outline-none"
                 />
               </label>
 
-              <div className="mt-4 flex justify-end">
+              <div className="mt-4 flex items-center justify-between gap-3">
+                <p className="text-xs font-medium text-slate-400">댓글 작성은 #85에서 연결 예정이에요.</p>
+
                 <button
                   type="button"
-                  className="inline-flex items-center gap-2 rounded-2xl bg-indigo-500 px-4 py-3 text-sm font-semibold text-white transition hover:bg-indigo-600"
+                  disabled
+                  className="inline-flex cursor-not-allowed items-center gap-2 rounded-2xl bg-slate-300 px-4 py-3 text-sm font-semibold text-white"
                 >
                   <SendHorizonal className="h-4 w-4" />
                   댓글 등록
@@ -154,53 +214,80 @@ const MainBoardSection = () => {
             </div>
 
             <div className="mt-5 space-y-3">
-              {selectedBoardComments.map((selectedBoardComment) => (
-                <article
-                  key={selectedBoardComment.id}
-                  className="rounded-[24px] border border-slate-200/80 bg-white px-5 py-4"
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <div className="text-sm font-semibold text-slate-900">
-                        {selectedBoardComment.author}
+              {isCommentsLoading ? (
+                <div className="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-6 text-center text-sm text-slate-500">
+                  댓글을 불러오는 중...
+                </div>
+              ) : null}
+
+              {isCommentsError ? (
+                <div className="rounded-[24px] border border-rose-200 bg-rose-50 px-5 py-6 text-center text-sm text-rose-600">
+                  댓글을 불러오지 못했어요.
+                  {commentsError instanceof Error ? ` ${commentsError.message}` : ''}
+                </div>
+              ) : null}
+
+              {!isCommentsLoading && !isCommentsError && selectedBoardComments.length === 0 ? (
+                <div className="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-6 text-center text-sm text-slate-500">
+                  아직 등록된 댓글이 없어요.
+                </div>
+              ) : null}
+
+              {!isCommentsLoading && !isCommentsError
+                ? selectedBoardComments.map((selectedBoardComment) => (
+                    <article
+                      key={selectedBoardComment.id}
+                      className="rounded-[24px] border border-slate-200/80 bg-white px-5 py-4"
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <div className="text-sm font-semibold text-slate-900">
+                            {selectedBoardComment.author}
+                          </div>
+                          <div className="mt-1 text-xs text-slate-400">
+                            {formatRelativeCreatedAt(selectedBoardComment.createdAt)}
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-3 text-xs font-medium text-slate-400">
+                          <span className="inline-flex items-center gap-1">
+                            <Heart className="h-3.5 w-3.5 text-rose-400" />
+                            {selectedBoardComment.likedCount}
+                          </span>
+
+                          {selectedBoardComment.isMine ? (
+                            <>
+                              <button
+                                type="button"
+                                disabled
+                                className="inline-flex cursor-not-allowed items-center gap-1 opacity-60"
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                                수정
+                              </button>
+                              <button
+                                type="button"
+                                disabled
+                                className="inline-flex cursor-not-allowed items-center gap-1 opacity-60"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                                삭제
+                              </button>
+                            </>
+                          ) : null}
+                        </div>
                       </div>
-                      <div className="mt-1 text-xs text-slate-400">
-                        {formatRelativeCreatedAt(selectedBoardComment.createdAt)}
-                      </div>
-                    </div>
 
-                    <div className="flex items-center gap-3 text-xs font-medium text-slate-400">
-                      <span className="inline-flex items-center gap-1">
-                        <Heart className="h-3.5 w-3.5 text-rose-400" />
-                        {selectedBoardComment.likedCount}
-                      </span>
+                      <p className="mt-3 text-sm leading-6 text-slate-600">
+                        {selectedBoardComment.content}
+                      </p>
 
-                      {selectedBoardComment.isMine ? (
-                        <>
-                          <button
-                            type="button"
-                            className="inline-flex items-center gap-1 hover:text-slate-600"
-                          >
-                            <Pencil className="h-3.5 w-3.5" />
-                            수정
-                          </button>
-                          <button
-                            type="button"
-                            className="inline-flex items-center gap-1 hover:text-slate-600"
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                            삭제
-                          </button>
-                        </>
-                      ) : null}
-                    </div>
-                  </div>
-
-                  <p className="mt-3 text-sm leading-6 text-slate-600">
-                    {selectedBoardComment.content}
-                  </p>
-                </article>
-              ))}
+                      <p className="mt-3 text-xs font-medium text-slate-400">
+                        댓글 좋아요는 #88, 수정은 #86, 삭제는 #87에서 연결 예정이에요.
+                      </p>
+                    </article>
+                  ))
+                : null}
             </div>
           </section>
         </article>

--- a/src/pages/profile/ui/ProfilePage.tsx
+++ b/src/pages/profile/ui/ProfilePage.tsx
@@ -8,7 +8,7 @@ import { MBTI_OPTIONS, type MbtiType, type UserProfile } from '@/shared/types/pr
 const EMPTY_PROFILE: UserProfile = {
   name: '',
   nickname: '',
-  bio: '',
+  introduce: '',
   mbti: '',
   profileImageUrl: '',
 };
@@ -19,7 +19,7 @@ const isMbtiType = (value: unknown): value is MbtiType =>
 const normalizeProfile = (profile: Partial<UserProfile> | null | undefined): UserProfile => ({
   name: typeof profile?.name === 'string' ? profile.name : '',
   nickname: typeof profile?.nickname === 'string' ? profile.nickname : '',
-  bio: typeof profile?.bio === 'string' ? profile.bio : '',
+  introduce: typeof profile?.introduce === 'string' ? profile.introduce : '',
   mbti: isMbtiType(profile?.mbti) ? profile.mbti : '',
   profileImageUrl: typeof profile?.profileImageUrl === 'string' ? profile.profileImageUrl : '',
 });
@@ -61,8 +61,9 @@ export default function ProfilePage() {
 
   const profile = profileDraft ?? normalizeProfile(profileData) ?? EMPTY_PROFILE;
 
+  const displayNickname = profile.nickname.trim() || '익명 사용자';
   const showProfileImage = Boolean(profile.profileImageUrl) && !imageError;
-  const profileInitial = profile.name.trim().charAt(0).toUpperCase() || 'P';
+  const profileInitial = displayNickname.trim().charAt(0).toUpperCase() || '익';
 
   const handleImageApply = () => {
     const nextImageUrl = imageInputValue.trim();
@@ -103,7 +104,7 @@ export default function ProfilePage() {
     updateProfileMutation.mutate({
       name: profile.name.trim(),
       nickname: profile.nickname.trim(),
-      bio: profile.bio.trim(),
+      introduce: profile.introduce.trim(),
       mbti: profile.mbti as MbtiType,
       profileImageUrl: profile.profileImageUrl.trim(),
     });
@@ -162,7 +163,7 @@ export default function ProfilePage() {
                 {showProfileImage ? (
                   <img
                     src={profile.profileImageUrl}
-                    alt={`${profile.name || '프로필'} profile`}
+                    alt={`${displayNickname} profile`}
                     className="h-full w-full object-cover"
                     onError={() => setImageError(true)}
                   />
@@ -218,7 +219,7 @@ export default function ProfilePage() {
             <div className="flex flex-1 flex-col justify-center text-center sm:text-left">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <h1 className="text-3xl font-semibold tracking-tight text-slate-900">
-                  {profile.name}
+                  {displayNickname}
                 </h1>
                 <div className="flex justify-center sm:justify-end">
                   <span className="inline-flex min-h-10 items-center justify-center rounded-full border border-slate-200 bg-slate-50 px-4 text-sm font-semibold text-slate-600">
@@ -226,11 +227,31 @@ export default function ProfilePage() {
                   </span>
                 </div>
               </div>
-              <p className="mt-2 text-lg text-slate-400">{profile.bio}</p>
+              <p className="mt-2 text-lg text-slate-400">{profile.introduce}</p>
+              <p className="mt-2 text-sm text-slate-500">
+                저장용 이름 {profile.name.trim() || '미입력'}
+              </p>
             </div>
           </div>
 
           <div className="mt-10 space-y-7">
+            <label className="block">
+              <span className="mb-3 block text-[18px] font-medium text-slate-800">닉네임</span>
+              <input
+                type="text"
+                value={profile.nickname}
+                onChange={(event) =>
+                  setProfileDraft((current) => ({
+                    ...profile,
+                    ...current,
+                    nickname: event.target.value,
+                  }))
+                }
+                placeholder="닉네임을 입력하세요"
+                className="h-16 w-full rounded-2xl border border-slate-100 bg-slate-50 px-6 text-lg text-slate-700 outline-none transition placeholder:text-slate-400 focus:border-indigo-200 focus:bg-white"
+              />
+            </label>
+
             <label className="block">
               <span className="mb-3 block text-[18px] font-medium text-slate-800">이름</span>
               <input
@@ -251,12 +272,12 @@ export default function ProfilePage() {
             <label className="block">
               <span className="mb-3 block text-[18px] font-medium text-slate-800">한줄소개</span>
               <textarea
-                value={profile.bio}
+                value={profile.introduce}
                 onChange={(event) =>
                   setProfileDraft((current) => ({
                     ...profile,
                     ...current,
-                    bio: event.target.value,
+                    introduce: event.target.value,
                   }))
                 }
                 placeholder="소개를 입력하세요"

--- a/src/shared/api/comments/comments.ts
+++ b/src/shared/api/comments/comments.ts
@@ -1,0 +1,55 @@
+import client from '@/shared/api/client';
+
+export interface GetCommentsParams {
+  page?: number;
+  size?: number;
+}
+
+export interface CommentListUserResponse {
+  id?: number;
+  nickname?: string;
+  name?: string;
+}
+
+export interface CommentListItemResponse {
+  id: number;
+  postId?: number | null;
+  userId?: number | null;
+  authorId?: number | null;
+  content: string;
+  likeCount?: number | null;
+  createdAt: string;
+  author?: string | null;
+  authorNickname?: string | null;
+  userNickname?: string | null;
+  nickname?: string | null;
+  isMine?: boolean | null;
+  user?: CommentListUserResponse | null;
+}
+
+export interface CommentListPaginationResponse {
+  page?: number;
+  size?: number;
+  totalCount?: number;
+  totalPages?: number;
+  hasNext?: boolean;
+}
+
+export interface GetCommentsResponse {
+  items: CommentListItemResponse[];
+  pagination?: CommentListPaginationResponse;
+}
+
+export async function getComments(
+  postId: number,
+  params: GetCommentsParams = {},
+): Promise<GetCommentsResponse> {
+  const response = await client.get<GetCommentsResponse>(`/api/v1/posts/${postId}/comments`, {
+    params: {
+      page: params.page,
+      size: params.size,
+    },
+  });
+
+  return response.data;
+}

--- a/src/shared/api/comments/commentsQueries.ts
+++ b/src/shared/api/comments/commentsQueries.ts
@@ -1,0 +1,12 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getComments, type GetCommentsParams } from './comments';
+
+export const commentQueries = {
+  all: () => ['comments'] as const,
+  lists: () => [...commentQueries.all(), 'list'] as const,
+  list: (postId: number, params: GetCommentsParams = {}) =>
+    queryOptions({
+      queryKey: [...commentQueries.lists(), postId, params],
+      queryFn: () => getComments(postId, params),
+    }),
+};

--- a/src/shared/api/comments/index.ts
+++ b/src/shared/api/comments/index.ts
@@ -1,0 +1,9 @@
+export type {
+  CommentListItemResponse,
+  CommentListPaginationResponse,
+  CommentListUserResponse,
+  GetCommentsParams,
+  GetCommentsResponse,
+} from './comments';
+export { getComments } from './comments';
+export { commentQueries } from './commentsQueries';

--- a/src/shared/api/users/index.ts
+++ b/src/shared/api/users/index.ts
@@ -1,0 +1,5 @@
+export type { GetMyUserResponse } from './me';
+export { getMyUser } from './me';
+export { myUserQueryOptions } from './meQueries';
+export { getMyProfile, updateMyProfile } from './profile';
+export { myProfileQueryOptions } from './profileQueries';

--- a/src/shared/api/users/me.ts
+++ b/src/shared/api/users/me.ts
@@ -1,0 +1,11 @@
+import client from '@/shared/api/client';
+
+export interface GetMyUserResponse {
+  id: number;
+}
+
+export async function getMyUser(): Promise<GetMyUserResponse> {
+  const response = await client.get<GetMyUserResponse>('/api/v1/users/me');
+
+  return response.data;
+}

--- a/src/shared/api/users/meQueries.ts
+++ b/src/shared/api/users/meQueries.ts
@@ -1,0 +1,8 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getMyUser } from '@/shared/api/users/me';
+
+export const myUserQueryOptions = () =>
+  queryOptions({
+    queryKey: ['myUser'],
+    queryFn: getMyUser,
+  });

--- a/src/shared/api/users/meQueries.ts
+++ b/src/shared/api/users/meQueries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from '@tanstack/react-query';
-import { getMyUser } from '@/shared/api/users/me';
+import { getMyUser } from './me';
 
 export const myUserQueryOptions = () =>
   queryOptions({


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 선택된 게시글 기준 댓글 목록을 `GET /api/v1/posts/{postId}/comments` 실제 조회로 전환했습니다.
- 댓글 섹션 안에서만 loading / error / empty 상태를 분리하고, 댓글 작성 / 수정 / 삭제 / 좋아요 UI는 후속 이슈 범위에 맞게 안내 / 비활성 상태로 정리했습니다.
- 댓글 작성자 표시와 내 댓글 여부는 응답 shape가 달라도 안전하게 렌더되도록 fallback 기준으로 매핑했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/comments/comments.ts`, `src/shared/api/comments/commentsQueries.ts`, `src/shared/api/comments/index.ts` 추가
- `src/shared/api/users/me.ts`, `src/shared/api/users/meQueries.ts` 추가
- `src/pages/main/ui/board/MainBoardSection.tsx`에서 `mockBoardComments` 제거, 선택 게시글 기준 댓글 목록 query 연결, 댓글 섹션 상태 분리, 후속 액션 UI 비활성 처리 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 댓글 목록 조회 연결과 댓글 섹션 상태 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 댓글 목록 조회는 `page=1`, `size=20` 고정으로 시작하고, 더보기 / 무한 스크롤은 이번 범위에 포함하지 않았습니다.
- 댓글 작성 / 수정 / 삭제 / 좋아요는 실제 액션 연결 없이 후속 이슈 안내 / 비활성 UI로만 남겨뒀습니다.
- 댓글 헤더 개수는 게시글 상세의 `commentCount`를 유지하고, 목록 조회 결과는 실제 댓글 렌더에만 사용합니다.
- 빌드 검증을 위해 기존 프로필 `bio` 필드 사용부를 `introduce`로 정리했습니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #84
