### PR TITLE
feat: (#86) 댓글 수정 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -8,6 +8,7 @@ import {
   createComment,
   type CommentListItemResponse,
   type GetCommentsResponse,
+  updateComment,
 } from '@/shared/api/comments';
 import { myUserQueryOptions } from '@/shared/api/users';
 import { cn } from '@/shared/lib/utils';
@@ -101,6 +102,38 @@ const getCreateCommentErrorMessage = (error: unknown) => {
   return '댓글을 등록하지 못했어요. 잠시 후 다시 시도해주세요.';
 };
 
+const getUpdateCommentErrorMessage = (error: unknown) => {
+  if (isAxiosError<ApiErrorPayload>(error)) {
+    const responseMessage = error.response?.data?.message;
+
+    if (Array.isArray(responseMessage) && responseMessage.length > 0) {
+      return responseMessage.join(' ');
+    }
+
+    if (typeof responseMessage === 'string' && responseMessage.trim() !== '') {
+      return responseMessage;
+    }
+
+    if (error.response?.status === 403) {
+      return '댓글을 수정할 권한이 없어요.';
+    }
+
+    if (error.response?.status === 404) {
+      return '댓글을 찾을 수 없어요.';
+    }
+
+    if (error.response?.status === 400) {
+      return '댓글 내용을 다시 확인해주세요.';
+    }
+  }
+
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+
+  return '댓글을 수정하지 못했어요. 잠시 후 다시 시도해주세요.';
+};
+
 interface MainBoardSectionProps {
   onRequireLogin: () => void;
 }
@@ -115,6 +148,11 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
   const [commentInputValue, setCommentInputValue] = useState('');
   const [commentActionMessage, setCommentActionMessage] = useState('');
   const [commentActionTone, setCommentActionTone] = useState<CommentActionTone>('success');
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editingCommentValue, setEditingCommentValue] = useState('');
+  const [commentEditMessage, setCommentEditMessage] = useState('');
+  const [commentEditMessageTone, setCommentEditMessageTone] =
+    useState<CommentActionTone>('success');
   const selectedBoardPost = boardPosts.find((boardPost) => boardPost.id === selectedBoardPostId);
   const isLoggedIn = isAuthenticated();
   const { data: currentUser } = useQuery({
@@ -185,6 +223,56 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
     },
   });
 
+  const updateCommentMutation = useMutation({
+    mutationFn: ({
+      postId,
+      commentId,
+      content,
+    }: {
+      postId: number;
+      commentId: number;
+      content: string;
+    }) => updateComment(postId, commentId, { content }),
+    onSuccess: (updatedComment, variables) => {
+      const queryParams = {
+        page: COMMENTS_LIST_DEFAULT_PAGE,
+        size: COMMENTS_LIST_DEFAULT_SIZE,
+      };
+
+      queryClient.setQueryData<GetCommentsResponse | undefined>(
+        commentQueries.list(variables.postId, queryParams).queryKey,
+        (oldData) => {
+          if (oldData === undefined) {
+            return oldData;
+          }
+
+          return {
+            ...oldData,
+            items: oldData.items.map((comment) =>
+              comment.id === variables.commentId ? { ...comment, ...updatedComment } : comment,
+            ),
+          };
+        },
+      );
+
+      setEditingCommentId(null);
+      setEditingCommentValue('');
+      setCommentEditMessage('댓글을 수정했어요.');
+      setCommentEditMessageTone('success');
+    },
+    onError: (error) => {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        setCommentEditMessage('로그인 후 댓글을 수정할 수 있어요.');
+        setCommentEditMessageTone('error');
+        onRequireLogin();
+        return;
+      }
+
+      setCommentEditMessage(getUpdateCommentErrorMessage(error));
+      setCommentEditMessageTone('error');
+    },
+  });
+
   const handleCommentSubmit = () => {
     if (selectedBoardPostId === null) {
       return;
@@ -205,6 +293,41 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
     });
   };
 
+  const handleCommentEditStart = (comment: MainBoardComment) => {
+    if (editingCommentId !== null && editingCommentId !== comment.id) {
+      return;
+    }
+
+    setCommentEditMessage('');
+    setCommentEditMessageTone('success');
+    setEditingCommentId(comment.id);
+    setEditingCommentValue(comment.content);
+  };
+
+  const handleCommentEditCancel = () => {
+    setEditingCommentId(null);
+    setEditingCommentValue('');
+    setCommentEditMessage('');
+    setCommentEditMessageTone('success');
+  };
+
+  const handleCommentUpdate = (comment: MainBoardComment) => {
+    const trimmedContent = editingCommentValue.trim();
+
+    if (trimmedContent === '') {
+      setCommentEditMessage('댓글 내용을 다시 확인해주세요.');
+      setCommentEditMessageTone('error');
+      return;
+    }
+
+    setCommentEditMessage('');
+    updateCommentMutation.mutate({
+      postId: comment.postId,
+      commentId: comment.id,
+      content: trimmedContent,
+    });
+  };
+
   return (
     <section className="space-y-4 md:space-y-5">
       {boardPosts.map((mockBoardPost) => (
@@ -216,7 +339,13 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
               ? 'border-indigo-200 ring-4 ring-indigo-100/60'
               : 'border-slate-200/80 hover:border-slate-300',
           )}
-          onClick={() => setSelectedBoardPostId(mockBoardPost.id)}
+          onClick={() => {
+            setSelectedBoardPostId(mockBoardPost.id);
+            setEditingCommentId(null);
+            setEditingCommentValue('');
+            setCommentEditMessage('');
+            setCommentEditMessageTone('success');
+          }}
         >
           <div className="flex items-center justify-between gap-3">
             <span
@@ -337,6 +466,19 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
             </div>
 
             <div className="mt-5 space-y-3">
+              {commentEditMessage !== '' ? (
+                <div
+                  className={cn(
+                    'rounded-[24px] border px-5 py-4 text-center text-sm',
+                    commentEditMessageTone === 'success'
+                      ? 'border-emerald-200 bg-emerald-50 text-emerald-600'
+                      : 'border-rose-200 bg-rose-50 text-rose-600',
+                  )}
+                >
+                  {commentEditMessage}
+                </div>
+              ) : null}
+
               {isCommentsLoading ? (
                 <div className="rounded-[24px] border border-slate-200 bg-slate-50 px-5 py-6 text-center text-sm text-slate-500">
                   댓글을 불러오는 중...
@@ -382,8 +524,20 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
                             <>
                               <button
                                 type="button"
-                                disabled
-                                className="inline-flex cursor-not-allowed items-center gap-1 opacity-60"
+                                onClick={() => handleCommentEditStart(selectedBoardComment)}
+                                disabled={
+                                  updateCommentMutation.isPending ||
+                                  (editingCommentId !== null &&
+                                    editingCommentId !== selectedBoardComment.id)
+                                }
+                                className={cn(
+                                  'inline-flex items-center gap-1',
+                                  updateCommentMutation.isPending ||
+                                    (editingCommentId !== null &&
+                                      editingCommentId !== selectedBoardComment.id)
+                                    ? 'cursor-not-allowed opacity-60'
+                                    : 'text-slate-500 hover:text-slate-700',
+                                )}
                               >
                                 <Pencil className="h-3.5 w-3.5" />
                                 수정
@@ -401,12 +555,51 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
                         </div>
                       </div>
 
-                      <p className="mt-3 text-sm leading-6 text-slate-600">
-                        {selectedBoardComment.content}
-                      </p>
+                      {editingCommentId === selectedBoardComment.id ? (
+                        <div className="mt-3 space-y-3">
+                          <textarea
+                            value={editingCommentValue}
+                            onChange={(event) => setEditingCommentValue(event.target.value)}
+                            className="min-h-[96px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-700 outline-none transition focus:border-indigo-300 focus:ring-4 focus:ring-indigo-100/70"
+                          />
+
+                          <div className="flex items-center justify-end gap-2">
+                            <button
+                              type="button"
+                              onClick={handleCommentEditCancel}
+                              disabled={updateCommentMutation.isPending}
+                              className={cn(
+                                'rounded-2xl px-4 py-2 text-sm font-semibold transition',
+                                updateCommentMutation.isPending
+                                  ? 'cursor-not-allowed bg-slate-100 text-slate-400'
+                                  : 'bg-slate-100 text-slate-600 hover:bg-slate-200',
+                              )}
+                            >
+                              취소
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleCommentUpdate(selectedBoardComment)}
+                              disabled={updateCommentMutation.isPending}
+                              className={cn(
+                                'rounded-2xl px-4 py-2 text-sm font-semibold text-white transition',
+                                updateCommentMutation.isPending
+                                  ? 'cursor-not-allowed bg-slate-300'
+                                  : 'bg-slate-900 hover:bg-slate-800',
+                              )}
+                            >
+                              {updateCommentMutation.isPending ? '수정 중...' : '수정 완료'}
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="mt-3 text-sm leading-6 text-slate-600">
+                          {selectedBoardComment.content}
+                        </p>
+                      )}
 
                       <p className="mt-3 text-xs font-medium text-slate-400">
-                        댓글 좋아요는 #88, 수정은 #86, 삭제는 #87에서 연결 예정이에요.
+                        댓글 좋아요는 #88, 삭제는 #87에서 연결 예정이에요.
                       </p>
                     </article>
                   ))

--- a/src/shared/api/comments/comments.ts
+++ b/src/shared/api/comments/comments.ts
@@ -48,6 +48,14 @@ export interface CreateCommentResponse extends CommentListItemResponse {
   postId: number;
 }
 
+export interface UpdateCommentRequest {
+  content: string;
+}
+
+export interface UpdateCommentResponse extends CommentListItemResponse {
+  postId: number;
+}
+
 export async function getComments(
   postId: number,
   params: GetCommentsParams = {},
@@ -67,6 +75,19 @@ export async function createComment(
   payload: CreateCommentRequest,
 ): Promise<CreateCommentResponse> {
   const response = await client.post<CreateCommentResponse>(`/api/v1/posts/${postId}/comments`, payload);
+
+  return response.data;
+}
+
+export async function updateComment(
+  postId: number,
+  commentId: number,
+  payload: UpdateCommentRequest,
+): Promise<UpdateCommentResponse> {
+  const response = await client.patch<UpdateCommentResponse>(
+    `/api/v1/posts/${postId}/comments/${commentId}`,
+    payload,
+  );
 
   return response.data;
 }

--- a/src/shared/api/comments/index.ts
+++ b/src/shared/api/comments/index.ts
@@ -6,6 +6,8 @@ export type {
   CommentListUserResponse,
   GetCommentsParams,
   GetCommentsResponse,
+  UpdateCommentRequest,
+  UpdateCommentResponse,
 } from './comments';
-export { createComment, getComments } from './comments';
+export { createComment, getComments, updateComment } from './comments';
 export { commentQueries } from './commentsQueries';


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 상세의 내 댓글 수정 버튼을 `PATCH /api/v1/posts/{postId}/comments/{commentId}` 실제 API와 연결했습니다.
- 댓글 카드를 인라인 수정 textarea로 전환하고, 별도 모달 없이 `취소` / `수정 완료` 흐름으로 처리하도록 정리했습니다.
- 수정 성공 시 댓글 개수는 유지한 채 해당 댓글만 즉시 갱신하고, `401` 응답은 로그인 모달로 이어지도록 연결했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/comments/comments.ts`에 `updateComment(postId, commentId, payload)`와 수정 요청 / 응답 타입 추가
- `src/shared/api/comments/index.ts` export 정리
- `src/pages/main/ui/board/MainBoardSection.tsx`에 인라인 수정 상태, 댓글 수정 mutation, 댓글 목록 캐시 대상 교체, 댓글 섹션 성공 / 실패 메시지 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 댓글 수정 연결과 인라인 수정 상태 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 수정 성공 시 전체 목록 refetch 대신 현재 댓글 목록 캐시에서 대상 댓글만 교체합니다.
- 댓글 헤더와 게시글 카드의 `commentCount`는 수정에서 변경되지 않습니다.
- `401`은 `로그인 후 댓글을 수정할 수 있어요.` 문구와 함께 로그인 모달을 열도록 연결했습니다.
- `403 / 404 / 400 / 기타` 실패는 댓글 섹션 안에서만 안내합니다.
- 댓글 삭제 / 좋아요는 이번 PR에서도 후속 이슈 상태를 유지합니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #86
