### PR TITLE
feat: (#87) 댓글 삭제 연결

### DIFF
--- a/src/pages/main/ui/board/MainBoardSection.tsx
+++ b/src/pages/main/ui/board/MainBoardSection.tsx
@@ -6,6 +6,7 @@ import { isAuthenticated } from '@/app/authSessionStore';
 import {
   commentQueries,
   createComment,
+  deleteComment,
   type CommentListItemResponse,
   type GetCommentsResponse,
   updateComment,
@@ -134,6 +135,34 @@ const getUpdateCommentErrorMessage = (error: unknown) => {
   return '댓글을 수정하지 못했어요. 잠시 후 다시 시도해주세요.';
 };
 
+const getDeleteCommentErrorMessage = (error: unknown) => {
+  if (isAxiosError<ApiErrorPayload>(error)) {
+    const responseMessage = error.response?.data?.message;
+
+    if (Array.isArray(responseMessage) && responseMessage.length > 0) {
+      return responseMessage.join(' ');
+    }
+
+    if (typeof responseMessage === 'string' && responseMessage.trim() !== '') {
+      return responseMessage;
+    }
+
+    if (error.response?.status === 403) {
+      return '댓글을 삭제할 권한이 없어요.';
+    }
+
+    if (error.response?.status === 404) {
+      return '댓글을 찾을 수 없어요.';
+    }
+  }
+
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+
+  return '댓글을 삭제하지 못했어요. 잠시 후 다시 시도해주세요.';
+};
+
 interface MainBoardSectionProps {
   onRequireLogin: () => void;
 }
@@ -152,6 +181,10 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
   const [editingCommentValue, setEditingCommentValue] = useState('');
   const [commentEditMessage, setCommentEditMessage] = useState('');
   const [commentEditMessageTone, setCommentEditMessageTone] =
+    useState<CommentActionTone>('success');
+  const [deletingCommentId, setDeletingCommentId] = useState<number | null>(null);
+  const [commentDeleteMessage, setCommentDeleteMessage] = useState('');
+  const [commentDeleteMessageTone, setCommentDeleteMessageTone] =
     useState<CommentActionTone>('success');
   const selectedBoardPost = boardPosts.find((boardPost) => boardPost.id === selectedBoardPostId);
   const isLoggedIn = isAuthenticated();
@@ -273,6 +306,55 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
     },
   });
 
+  const deleteCommentMutation = useMutation({
+    mutationFn: ({ postId, commentId }: { postId: number; commentId: number }) =>
+      deleteComment(postId, commentId),
+    onSuccess: (_, variables) => {
+      const queryParams = {
+        page: COMMENTS_LIST_DEFAULT_PAGE,
+        size: COMMENTS_LIST_DEFAULT_SIZE,
+      };
+
+      queryClient.setQueryData<GetCommentsResponse | undefined>(
+        commentQueries.list(variables.postId, queryParams).queryKey,
+        (oldData) => {
+          if (oldData === undefined) {
+            return oldData;
+          }
+
+          return {
+            ...oldData,
+            items: oldData.items.filter((comment) => comment.id !== variables.commentId),
+          };
+        },
+      );
+
+      setBoardPosts((currentBoardPosts) =>
+        currentBoardPosts.map((boardPost) =>
+          boardPost.id === variables.postId
+            ? { ...boardPost, commentCount: Math.max(0, boardPost.commentCount - 1) }
+            : boardPost,
+        ),
+      );
+      setDeletingCommentId(null);
+      setEditingCommentId(null);
+      setEditingCommentValue('');
+      setCommentDeleteMessage('댓글을 삭제했어요.');
+      setCommentDeleteMessageTone('success');
+    },
+    onError: (error) => {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        setCommentDeleteMessage('로그인 후 댓글을 삭제할 수 있어요.');
+        setCommentDeleteMessageTone('error');
+        onRequireLogin();
+        return;
+      }
+
+      setCommentDeleteMessage(getDeleteCommentErrorMessage(error));
+      setCommentDeleteMessageTone('error');
+    },
+  });
+
   const handleCommentSubmit = () => {
     if (selectedBoardPostId === null) {
       return;
@@ -298,6 +380,9 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
       return;
     }
 
+    setDeletingCommentId(null);
+    setCommentDeleteMessage('');
+    setCommentDeleteMessageTone('success');
     setCommentEditMessage('');
     setCommentEditMessageTone('success');
     setEditingCommentId(comment.id);
@@ -328,6 +413,34 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
     });
   };
 
+  const handleCommentDeleteStart = (commentId: number) => {
+    if (deletingCommentId !== null && deletingCommentId !== commentId) {
+      return;
+    }
+
+    setEditingCommentId(null);
+    setEditingCommentValue('');
+    setCommentEditMessage('');
+    setCommentEditMessageTone('success');
+    setCommentDeleteMessage('');
+    setCommentDeleteMessageTone('success');
+    setDeletingCommentId(commentId);
+  };
+
+  const handleCommentDeleteCancel = () => {
+    setDeletingCommentId(null);
+    setCommentDeleteMessage('');
+    setCommentDeleteMessageTone('success');
+  };
+
+  const handleCommentDelete = (comment: MainBoardComment) => {
+    setCommentDeleteMessage('');
+    deleteCommentMutation.mutate({
+      postId: comment.postId,
+      commentId: comment.id,
+    });
+  };
+
   return (
     <section className="space-y-4 md:space-y-5">
       {boardPosts.map((mockBoardPost) => (
@@ -345,6 +458,9 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
             setEditingCommentValue('');
             setCommentEditMessage('');
             setCommentEditMessageTone('success');
+            setDeletingCommentId(null);
+            setCommentDeleteMessage('');
+            setCommentDeleteMessageTone('success');
           }}
         >
           <div className="flex items-center justify-between gap-3">
@@ -466,6 +582,19 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
             </div>
 
             <div className="mt-5 space-y-3">
+              {commentDeleteMessage !== '' ? (
+                <div
+                  className={cn(
+                    'rounded-[24px] border px-5 py-4 text-center text-sm',
+                    commentDeleteMessageTone === 'success'
+                      ? 'border-emerald-200 bg-emerald-50 text-emerald-600'
+                      : 'border-rose-200 bg-rose-50 text-rose-600',
+                  )}
+                >
+                  {commentDeleteMessage}
+                </div>
+              ) : null}
+
               {commentEditMessage !== '' ? (
                 <div
                   className={cn(
@@ -527,12 +656,16 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
                                 onClick={() => handleCommentEditStart(selectedBoardComment)}
                                 disabled={
                                   updateCommentMutation.isPending ||
+                                  deleteCommentMutation.isPending ||
+                                  deletingCommentId !== null ||
                                   (editingCommentId !== null &&
                                     editingCommentId !== selectedBoardComment.id)
                                 }
                                 className={cn(
                                   'inline-flex items-center gap-1',
                                   updateCommentMutation.isPending ||
+                                    deleteCommentMutation.isPending ||
+                                    deletingCommentId !== null ||
                                     (editingCommentId !== null &&
                                       editingCommentId !== selectedBoardComment.id)
                                     ? 'cursor-not-allowed opacity-60'
@@ -544,8 +677,22 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
                               </button>
                               <button
                                 type="button"
-                                disabled
-                                className="inline-flex cursor-not-allowed items-center gap-1 opacity-60"
+                                onClick={() => handleCommentDeleteStart(selectedBoardComment.id)}
+                                disabled={
+                                  deleteCommentMutation.isPending ||
+                                  editingCommentId !== null ||
+                                  (deletingCommentId !== null &&
+                                    deletingCommentId !== selectedBoardComment.id)
+                                }
+                                className={cn(
+                                  'inline-flex items-center gap-1',
+                                  deleteCommentMutation.isPending ||
+                                    editingCommentId !== null ||
+                                    (deletingCommentId !== null &&
+                                      deletingCommentId !== selectedBoardComment.id)
+                                    ? 'cursor-not-allowed opacity-60'
+                                    : 'text-slate-500 hover:text-rose-600',
+                                )}
                               >
                                 <Trash2 className="h-3.5 w-3.5" />
                                 삭제
@@ -598,8 +745,44 @@ const MainBoardSection = ({ onRequireLogin }: MainBoardSectionProps) => {
                         </p>
                       )}
 
+                      {deletingCommentId === selectedBoardComment.id ? (
+                        <div className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-4">
+                          <p className="text-sm font-medium text-rose-700">
+                            정말 삭제할까요?
+                          </p>
+                          <div className="mt-3 flex items-center justify-end gap-2">
+                            <button
+                              type="button"
+                              onClick={handleCommentDeleteCancel}
+                              disabled={deleteCommentMutation.isPending}
+                              className={cn(
+                                'rounded-2xl px-4 py-2 text-sm font-semibold transition',
+                                deleteCommentMutation.isPending
+                                  ? 'cursor-not-allowed bg-white text-slate-400'
+                                  : 'bg-white text-slate-600 hover:bg-slate-100',
+                              )}
+                            >
+                              취소
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleCommentDelete(selectedBoardComment)}
+                              disabled={deleteCommentMutation.isPending}
+                              className={cn(
+                                'rounded-2xl px-4 py-2 text-sm font-semibold text-white transition',
+                                deleteCommentMutation.isPending
+                                  ? 'cursor-not-allowed bg-rose-300'
+                                  : 'bg-rose-500 hover:bg-rose-600',
+                              )}
+                            >
+                              {deleteCommentMutation.isPending ? '삭제 중...' : '삭제'}
+                            </button>
+                          </div>
+                        </div>
+                      ) : null}
+
                       <p className="mt-3 text-xs font-medium text-slate-400">
-                        댓글 좋아요는 #88, 삭제는 #87에서 연결 예정이에요.
+                        댓글 좋아요는 #88에서 연결 예정이에요.
                       </p>
                     </article>
                   ))

--- a/src/shared/api/comments/comments.ts
+++ b/src/shared/api/comments/comments.ts
@@ -91,3 +91,7 @@ export async function updateComment(
 
   return response.data;
 }
+
+export async function deleteComment(postId: number, commentId: number): Promise<void> {
+  await client.delete(`/api/v1/posts/${postId}/comments/${commentId}`);
+}

--- a/src/shared/api/comments/index.ts
+++ b/src/shared/api/comments/index.ts
@@ -9,5 +9,5 @@ export type {
   UpdateCommentRequest,
   UpdateCommentResponse,
 } from './comments';
-export { createComment, getComments, updateComment } from './comments';
+export { createComment, deleteComment, getComments, updateComment } from './comments';
 export { commentQueries } from './commentsQueries';


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- BOARD 상세의 내 댓글 삭제 버튼을 `DELETE /api/v1/posts/{postId}/comments/{commentId}` 실제 API와 연결했습니다.
- 댓글 카드 안에서 한 번 더 확인한 뒤 삭제하는 인라인 확인 UX로 정리하고, 별도 모달 없이 `취소` / `삭제` 흐름으로 처리했습니다.
- 삭제 성공 시 댓글 목록에서 해당 댓글을 즉시 제거하고, 댓글 헤더와 게시글 카드의 `commentCount`를 함께 `-1` 반영하도록 연결했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/api/comments/comments.ts`에 `deleteComment(postId, commentId)` 추가
- `src/shared/api/comments/index.ts` export 정리
- `src/pages/main/ui/board/MainBoardSection.tsx`에 인라인 삭제 확인 상태, 댓글 삭제 mutation, 댓글 목록 캐시 제거, 댓글 섹션 성공 / 실패 메시지, `commentCount` 동기화 추가

## 📸 스크린샷 (Screenshots)

- 별도 스크린샷은 없습니다.
- 이번 PR은 BOARD 댓글 삭제 연결과 인라인 삭제 확인 상태 정리 중심 작업입니다.

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 삭제 성공 시 전체 목록 refetch 대신 현재 댓글 목록 캐시에서 대상 댓글만 제거합니다.
- 댓글 헤더와 게시글 카드의 `commentCount`는 삭제에서만 `-1` 변경됩니다.
- `401`은 `로그인 후 댓글을 삭제할 수 있어요.` 문구와 함께 로그인 모달을 열도록 연결했습니다.
- `403 / 404 / 기타` 실패는 댓글 섹션 안에서만 안내합니다.
- 댓글 좋아요는 이번 PR에서도 후속 이슈 상태를 유지합니다.
- `corepack pnpm build` 기준으로 빌드 통과를 확인했습니다.

## 🧐 이슈 (Related Issues)

- Closes #87
