### PR TITLE
feat: (138) 회원가입 기능 구현

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,6 +1,6 @@
 import MainPage from '@/pages/main';
 import { ProfilePage } from '@/pages/profile';
-import LoginPage from '@/pages/user';
+import { SignUpPage } from '@/pages/user';
 
 const routes = [
   {
@@ -12,8 +12,8 @@ const routes = [
     element: <ProfilePage />,
   },
   {
-    path: '/login',
-    element: <LoginPage />,
+    path: '/signup',
+    element: <SignUpPage />,
   },
 ];
 

--- a/src/entities/user/api/auth.ts
+++ b/src/entities/user/api/auth.ts
@@ -1,14 +1,26 @@
 import client from '@/shared/api/client';
-import type { LoginRequest, LoginResponse, LogoutResponse } from '../model/types';
+import type {
+  LoginRequest,
+  LoginResponse,
+  LogoutResponse,
+  SignUpRequest,
+  SignUpResponse,
+} from '../model/types';
 
 export async function login(payload: LoginRequest): Promise<LoginResponse> {
-  const response = await client.post<LoginResponse>('/api/v1/auth/login', payload);
+  const response = await client.post<LoginResponse>('/auth/login', payload);
 
   return response.data;
 }
 
 export async function logout(): Promise<LogoutResponse> {
-  const response = await client.post<LogoutResponse>('/api/v1/auth/logout');
+  const response = await client.post<LogoutResponse>('/auth/logout');
+
+  return response.data;
+}
+
+export async function signup(payload: SignUpRequest): Promise<SignUpResponse> {
+  const response = await client.post<SignUpResponse>('/auth/signup', payload);
 
   return response.data;
 }

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,4 +1,4 @@
-export { login, logout } from './api/auth';
+export { login, logout, signup } from './api/auth';
 export { deleteMyUser, getMyUser, updateMyUser } from './api/me';
 export { myUserQueryOptions } from './api/meQueries';
 export { getMyProfile, updateMyProfile } from './api/profile';
@@ -15,6 +15,8 @@ export type {
   DeleteMyUserResponse,
   Gender,
   GetMyUserResponse,
+  SignUpRequest,
+  SignUpResponse,
   LoginRequest,
   LoginResponse,
   LogoutResponse,

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -1,6 +1,6 @@
 import type { MbtiType } from './profile';
 
-export type Gender = 'MALE' | 'FEMALE' | 'ANY';
+export type Gender = 'MALE' | 'FEMALE';
 
 export interface User {
   id: number;
@@ -16,6 +16,24 @@ export interface User {
 }
 
 export type GetMyUserResponse = User;
+
+export interface SignUpRequest {
+  email: string;
+  password: string;
+  name: string;
+  nickname: string;
+  birthDate: string;
+  gender: Gender;
+  schoolInfo?: string;
+  introduce?: string;
+  mbti?: string;
+}
+
+export interface SignUpResponse {
+  accessToken: string;
+  refreshToken: string;
+  user: User;
+}
 
 export interface LoginRequest {
   email: string;

--- a/src/features/auth/sign-up/ui/SignUpForm.tsx
+++ b/src/features/auth/sign-up/ui/SignUpForm.tsx
@@ -1,6 +1,16 @@
-import { useId } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import { useId, type ChangeEvent } from 'react';
 import { useForm } from 'react-hook-form';
-import { MBTI_OPTIONS, type Gender, type MbtiType } from '@/entities/user';
+import {
+  myProfileQueryOptions,
+  myUserQueryOptions,
+  signup,
+  type Gender,
+  type MbtiType,
+  MBTI_OPTIONS,
+} from '@/entities/user';
+import { setAuthAccessToken } from '@/shared/lib/auth/session';
 import AuthField from '@/shared/ui/auth/AuthField';
 import AuthSubmitButton from '@/shared/ui/auth/AuthSubmitButton';
 
@@ -14,7 +24,9 @@ interface SignUpFormValues {
   email: string;
   password: string;
   passwordConfirm: string;
-  birthDate: string;
+  birthYear: string;
+  birthMonth: string;
+  birthDay: string;
   gender: Gender | '';
   schoolInfo: string;
   introduce: string;
@@ -32,7 +44,9 @@ const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
   const signupEmailId = useId();
   const signupPasswordId = useId();
   const signupPasswordConfirmId = useId();
-  const signupBirthDateId = useId();
+  const signupBirthYearId = useId();
+  const signupBirthMonthId = useId();
+  const signupBirthDayId = useId();
   const signupSchoolInfoId = useId();
   const signupIntroduceId = useId();
   const signUpForm = useForm<SignUpFormValues>({
@@ -42,7 +56,9 @@ const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
       email: '',
       password: '',
       passwordConfirm: '',
-      birthDate: '',
+      birthYear: '',
+      birthMonth: '',
+      birthDay: '',
       gender: '',
       schoolInfo: '',
       introduce: '',
@@ -53,13 +69,66 @@ const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
   const gender = signUpForm.watch('gender');
   const mbti = signUpForm.watch('mbti');
   const { errors } = signUpForm.formState;
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: signup,
+    onSuccess: async (data) => {
+      setAuthAccessToken(data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
+      queryClient.setQueryData(myUserQueryOptions().queryKey, data.user);
+      await queryClient.invalidateQueries({ queryKey: myProfileQueryOptions().queryKey });
+      onSuccess();
+    },
+    onError: (err: unknown) => {
+      const message =
+        axios.isAxiosError(err) && err.response?.status === 409
+          ? '이미 가입된 이메일입니다.'
+          : '회원가입 중 오류가 발생했습니다.';
+      signUpForm.setError('root', { message });
+    },
+  });
+
+  const passwordRegistration = signUpForm.register('password', {
+    required: '비밀번호를 입력해 주세요.',
+    minLength: { value: 8, message: '비밀번호는 8자 이상이어야 합니다.' },
+  });
 
   const onSubmit = signUpForm.handleSubmit((data) => {
     if (!data.gender) {
       signUpForm.setError('gender', { message: '성별을 선택해 주세요.' });
       return;
     }
-    onSuccess();
+
+    const year = Number(data.birthYear);
+    const month = Number(data.birthMonth);
+    const day = Number(data.birthDay);
+    const birthDateObj = new Date(year, month - 1, day);
+    const isRealDate =
+      birthDateObj.getFullYear() === year &&
+      birthDateObj.getMonth() === month - 1 &&
+      birthDateObj.getDate() === day;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    if (!isRealDate || birthDateObj > today || year < 1900) {
+      signUpForm.setError('birthYear', { message: '생년월일을 확인해 주세요.' });
+      return;
+    }
+
+    const birthDate = `${data.birthYear}-${data.birthMonth.padStart(2, '0')}-${data.birthDay.padStart(2, '0')}`;
+
+    mutate({
+      name: data.name.trim(),
+      nickname: data.nickname.trim(),
+      email: data.email.trim(),
+      password: data.password,
+      birthDate,
+      gender: data.gender,
+      schoolInfo: data.schoolInfo.trim() || undefined,
+      introduce: data.introduce.trim() || undefined,
+      mbti: data.mbti || undefined,
+    });
   });
 
   return (
@@ -74,7 +143,9 @@ const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
           label="이름"
           placeholder="이름을 입력하세요"
           inputClassName="h-13"
-          registration={signUpForm.register('name', { required: '이름을 입력해 주세요.' })}
+          registration={signUpForm.register('name', {
+            validate: (value) => value.trim().length > 0 || '이름을 입력해 주세요.',
+          })}
           error={errors.name?.message}
         />
         <AuthField
@@ -83,7 +154,9 @@ const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
           label="닉네임"
           placeholder="닉네임을 입력하세요"
           inputClassName="h-13"
-          registration={signUpForm.register('nickname', { required: '닉네임을 입력해 주세요.' })}
+          registration={signUpForm.register('nickname', {
+            validate: (value) => value.trim().length > 0 || '닉네임을 입력해 주세요.',
+          })}
           error={errors.nickname?.message}
         />
         <AuthField
@@ -107,10 +180,15 @@ const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
           label="비밀번호"
           placeholder="비밀번호를 입력하세요"
           inputClassName="h-13"
-          registration={signUpForm.register('password', {
-            required: '비밀번호를 입력해 주세요.',
-            minLength: { value: 8, message: '비밀번호는 8자 이상이어야 합니다.' },
-          })}
+          registration={{
+            ...passwordRegistration,
+            onChange: (event: ChangeEvent<HTMLInputElement>) => {
+              passwordRegistration.onChange(event);
+              if (signUpForm.getValues('passwordConfirm')) {
+                void signUpForm.trigger('passwordConfirm');
+              }
+            },
+          }}
           error={errors.password?.message}
         />
         <AuthField
@@ -126,17 +204,64 @@ const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
           })}
           error={errors.passwordConfirm?.message}
         />
-        <AuthField
-          id={signupBirthDateId}
-          type="date"
-          label="생년월일"
-          placeholder="생년월일을 입력하세요"
-          inputClassName="h-13"
-          registration={signUpForm.register('birthDate', {
-            required: '생년월일을 입력해 주세요.',
-          })}
-          error={errors.birthDate?.message}
-        />
+        <div className="space-y-2.5">
+          <span className="text-sm font-semibold text-slate-900">생년월일</span>
+          <div className="grid grid-cols-3 gap-2">
+            <input
+              id={signupBirthYearId}
+              type="number"
+              placeholder="년도"
+              aria-label="출생 연도"
+              className={`h-13 w-full rounded-2xl border bg-white px-4 text-base text-slate-900 outline-none transition placeholder:text-slate-400 focus:ring-4 ${
+                errors.birthYear
+                  ? 'border-red-400 focus:border-red-400 focus:ring-red-100'
+                  : 'border-slate-200 focus:border-indigo-300 focus:ring-indigo-100'
+              }`}
+              {...signUpForm.register('birthYear', {
+                required: '생년월일을 입력해 주세요.',
+                pattern: { value: /^\d{4}$/, message: '생년월일을 확인해 주세요.' },
+              })}
+            />
+            <input
+              id={signupBirthMonthId}
+              type="number"
+              placeholder="월"
+              aria-label="출생 월"
+              className={`h-13 w-full rounded-2xl border bg-white px-4 text-base text-slate-900 outline-none transition placeholder:text-slate-400 focus:ring-4 ${
+                errors.birthMonth
+                  ? 'border-red-400 focus:border-red-400 focus:ring-red-100'
+                  : 'border-slate-200 focus:border-indigo-300 focus:ring-indigo-100'
+              }`}
+              {...signUpForm.register('birthMonth', {
+                required: '생년월일을 입력해 주세요.',
+                pattern: { value: /^(0?[1-9]|1[0-2])$/, message: '생년월일을 확인해 주세요.' },
+              })}
+            />
+            <input
+              id={signupBirthDayId}
+              type="number"
+              placeholder="일"
+              aria-label="출생 일"
+              className={`h-13 w-full rounded-2xl border bg-white px-4 text-base text-slate-900 outline-none transition placeholder:text-slate-400 focus:ring-4 ${
+                errors.birthDay
+                  ? 'border-red-400 focus:border-red-400 focus:ring-red-100'
+                  : 'border-slate-200 focus:border-indigo-300 focus:ring-indigo-100'
+              }`}
+              {...signUpForm.register('birthDay', {
+                required: '생년월일을 입력해 주세요.',
+                pattern: {
+                  value: /^(0?[1-9]|[12]\d|3[01])$/,
+                  message: '생년월일을 확인해 주세요.',
+                },
+              })}
+            />
+          </div>
+          {(errors.birthYear || errors.birthMonth || errors.birthDay) && (
+            <p className="pl-1 text-xs text-red-500">
+              {errors.birthYear?.message ?? errors.birthMonth?.message ?? errors.birthDay?.message}
+            </p>
+          )}
+        </div>
         <div className="space-y-2.5">
           <span className="text-sm font-semibold text-slate-900">성별</span>
           <div className="grid grid-cols-2 gap-3">
@@ -205,7 +330,11 @@ const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
         </div>
       </div>
 
-      <AuthSubmitButton label="회원가입" />
+      {errors.root && (
+        <p className="mb-2 text-center text-xs font-medium text-red-500">{errors.root.message}</p>
+      )}
+
+      <AuthSubmitButton label="회원가입" pendingLabel="가입 중..." isPending={isPending} />
     </form>
   );
 };

--- a/src/features/auth/sign-up/ui/SignUpForm.tsx
+++ b/src/features/auth/sign-up/ui/SignUpForm.tsx
@@ -1,12 +1,11 @@
-import { Eye } from 'lucide-react';
 import { useId } from 'react';
 import { useForm } from 'react-hook-form';
+import { MBTI_OPTIONS, type Gender, type MbtiType } from '@/entities/user';
 import AuthField from '@/shared/ui/auth/AuthField';
 import AuthSubmitButton from '@/shared/ui/auth/AuthSubmitButton';
 
 interface SignUpFormProps {
   onSuccess: () => void;
-  onSwitchToSignIn: () => void;
 }
 
 interface SignUpFormValues {
@@ -15,14 +14,27 @@ interface SignUpFormValues {
   email: string;
   password: string;
   passwordConfirm: string;
+  birthDate: string;
+  gender: Gender | '';
+  schoolInfo: string;
+  introduce: string;
+  mbti: MbtiType | '';
 }
 
-const SignUpForm = ({ onSuccess, onSwitchToSignIn }: SignUpFormProps) => {
+const GENDER_OPTIONS = [
+  { value: 'MALE', label: '남성' },
+  { value: 'FEMALE', label: '여성' },
+] as const;
+
+const SignUpForm = ({ onSuccess }: SignUpFormProps) => {
   const signupNameId = useId();
   const signupNicknameId = useId();
   const signupEmailId = useId();
   const signupPasswordId = useId();
   const signupPasswordConfirmId = useId();
+  const signupBirthDateId = useId();
+  const signupSchoolInfoId = useId();
+  const signupIntroduceId = useId();
   const signUpForm = useForm<SignUpFormValues>({
     defaultValues: {
       name: '',
@@ -30,24 +42,40 @@ const SignUpForm = ({ onSuccess, onSwitchToSignIn }: SignUpFormProps) => {
       email: '',
       password: '',
       passwordConfirm: '',
+      birthDate: '',
+      gender: '',
+      schoolInfo: '',
+      introduce: '',
+      mbti: '',
     },
+  });
+
+  const gender = signUpForm.watch('gender');
+  const mbti = signUpForm.watch('mbti');
+  const { errors } = signUpForm.formState;
+
+  const onSubmit = signUpForm.handleSubmit((data) => {
+    if (!data.gender) {
+      signUpForm.setError('gender', { message: '성별을 선택해 주세요.' });
+      return;
+    }
+    onSuccess();
   });
 
   return (
     <form
-      onSubmit={signUpForm.handleSubmit(() => {
-        onSuccess();
-      })}
-      className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.06)] md:p-7"
+      onSubmit={onSubmit}
+      className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_18px_40px_rgba(15,23,42,0.06)]"
     >
-      <div className="space-y-4">
+      <div className="space-y-4 mb-5">
         <AuthField
           id={signupNameId}
           type="text"
           label="이름"
           placeholder="이름을 입력하세요"
           inputClassName="h-13"
-          registration={signUpForm.register('name')}
+          registration={signUpForm.register('name', { required: '이름을 입력해 주세요.' })}
+          error={errors.name?.message}
         />
         <AuthField
           id={signupNicknameId}
@@ -55,7 +83,8 @@ const SignUpForm = ({ onSuccess, onSwitchToSignIn }: SignUpFormProps) => {
           label="닉네임"
           placeholder="닉네임을 입력하세요"
           inputClassName="h-13"
-          registration={signUpForm.register('nickname')}
+          registration={signUpForm.register('nickname', { required: '닉네임을 입력해 주세요.' })}
+          error={errors.nickname?.message}
         />
         <AuthField
           id={signupEmailId}
@@ -63,7 +92,14 @@ const SignUpForm = ({ onSuccess, onSwitchToSignIn }: SignUpFormProps) => {
           label="이메일"
           placeholder="example@university.ac.kr"
           inputClassName="h-13"
-          registration={signUpForm.register('email')}
+          registration={signUpForm.register('email', {
+            required: '이메일을 입력해 주세요.',
+            pattern: {
+              value: /\S+@\S+\.\S+/,
+              message: '이메일 형식이 올바르지 않습니다.',
+            },
+          })}
+          error={errors.email?.message}
         />
         <AuthField
           id={signupPasswordId}
@@ -71,8 +107,11 @@ const SignUpForm = ({ onSuccess, onSwitchToSignIn }: SignUpFormProps) => {
           label="비밀번호"
           placeholder="비밀번호를 입력하세요"
           inputClassName="h-13"
-          trailing={<Eye className="h-5 w-5" />}
-          registration={signUpForm.register('password')}
+          registration={signUpForm.register('password', {
+            required: '비밀번호를 입력해 주세요.',
+            minLength: { value: 8, message: '비밀번호는 8자 이상이어야 합니다.' },
+          })}
+          error={errors.password?.message}
         />
         <AuthField
           id={signupPasswordConfirmId}
@@ -80,23 +119,93 @@ const SignUpForm = ({ onSuccess, onSwitchToSignIn }: SignUpFormProps) => {
           label="비밀번호 확인"
           placeholder="비밀번호를 다시 입력하세요"
           inputClassName="h-13"
-          trailing={<Eye className="h-5 w-5" />}
-          registration={signUpForm.register('passwordConfirm')}
+          registration={signUpForm.register('passwordConfirm', {
+            required: '비밀번호를 다시 입력해 주세요.',
+            validate: (value) =>
+              value === signUpForm.watch('password') || '비밀번호가 일치하지 않습니다.',
+          })}
+          error={errors.passwordConfirm?.message}
         />
+        <AuthField
+          id={signupBirthDateId}
+          type="date"
+          label="생년월일"
+          placeholder="생년월일을 입력하세요"
+          inputClassName="h-13"
+          registration={signUpForm.register('birthDate', {
+            required: '생년월일을 입력해 주세요.',
+          })}
+          error={errors.birthDate?.message}
+        />
+        <div className="space-y-2.5">
+          <span className="text-sm font-semibold text-slate-900">성별</span>
+          <div className="grid grid-cols-2 gap-3">
+            {GENDER_OPTIONS.map((option) => {
+              const isSelected = gender === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    signUpForm.setValue('gender', option.value);
+                    signUpForm.clearErrors('gender');
+                  }}
+                  aria-pressed={isSelected}
+                  className={`h-13 rounded-2xl border text-sm font-semibold transition ${
+                    isSelected
+                      ? 'border-indigo-500 bg-indigo-500 text-white'
+                      : 'border-slate-200 bg-white text-slate-700 hover:border-indigo-200 hover:bg-slate-50'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+          {errors.gender && <p className="pl-1 text-xs text-red-500">{errors.gender.message}</p>}
+        </div>
+        <AuthField
+          id={signupSchoolInfoId}
+          type="text"
+          label="학교 정보"
+          placeholder="학교 정보를 입력하세요 (선택)"
+          inputClassName="h-13"
+          registration={signUpForm.register('schoolInfo')}
+        />
+        <AuthField
+          id={signupIntroduceId}
+          type="text"
+          label="자기소개"
+          placeholder="자기소개를 입력하세요 (선택)"
+          inputClassName="h-13"
+          registration={signUpForm.register('introduce')}
+        />
+        <div className="space-y-2.5">
+          <span className="text-sm font-semibold text-slate-900">MBTI</span>
+          <div className="grid grid-cols-4 gap-2">
+            {MBTI_OPTIONS.map((option) => {
+              const isSelected = mbti === option;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => signUpForm.setValue('mbti', option)}
+                  aria-pressed={isSelected}
+                  className={`h-11 rounded-2xl border text-sm font-semibold transition ${
+                    isSelected
+                      ? 'border-indigo-500 bg-indigo-500 text-white'
+                      : 'border-slate-200 bg-white text-slate-700 hover:border-indigo-200 hover:bg-slate-50'
+                  }`}
+                >
+                  {option}
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
 
       <AuthSubmitButton label="회원가입" />
-
-      <p className="mt-5 text-center text-sm text-slate-500">
-        이미 계정이 있으신가요?{' '}
-        <button
-          type="button"
-          onClick={onSwitchToSignIn}
-          className="font-semibold text-indigo-500 hover:text-indigo-600"
-        >
-          로그인
-        </button>
-      </p>
     </form>
   );
 };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -19,6 +19,8 @@ import type {
   LoginRequest,
   LoginResponse,
   LogoutResponse,
+  SignUpRequest,
+  SignUpResponse,
   UpdateMyUserRequest,
 } from '@/entities/user';
 import type { GetFriendRequestsResponse, GetFriendsResponse } from '@/entities/friend';
@@ -37,7 +39,7 @@ let currentUser: GetMyUserResponse = {
   mbti: 'ENFP',
   introduce: '오늘도 같이 먹을 사람을 찾고 있어요.',
   birthDate: '2000-05-15',
-  gender: 'ANY',
+  gender: 'MALE',
   createdAt: '2025-03-01T09:00:00.000Z',
 };
 
@@ -403,7 +405,7 @@ const toPostListItem = (post: PostDetailResponse): PostListItemResponse => ({
 });
 
 export const handlers = [
-  http.post('/api/v1/auth/login', async ({ request }) => {
+  http.post('/auth/login', async ({ request }) => {
     await wait();
     if (isAccountDeleted) {
       return HttpResponse.json({ message: '탈퇴한 계정입니다.' }, { status: 410 });
@@ -422,7 +424,7 @@ export const handlers = [
     });
   }),
 
-  http.post('/api/v1/auth/logout', async ({ request }) => {
+  http.post('/auth/logout', async ({ request }) => {
     await wait();
     if (!isAuthorized(request)) {
       return unauthorizedResponse();
@@ -430,6 +432,49 @@ export const handlers = [
 
     return HttpResponse.json<LogoutResponse>({
       message: '로그아웃되었습니다.',
+    });
+  }),
+
+  http.post('/auth/signup', async ({ request }) => {
+    await wait();
+
+    const payload = (await request.json()) as SignUpRequest;
+
+    if (
+      !payload.name?.trim() ||
+      !payload.nickname?.trim() ||
+      !payload.email?.trim() ||
+      !payload.password?.trim() ||
+      !payload.birthDate?.trim() ||
+      !payload.gender
+    ) {
+      return HttpResponse.json({ message: '필수 정보를 모두 입력해 주세요.' }, { status: 400 });
+    }
+
+    if (mockUsers.some((user) => user.email === payload.email)) {
+      return HttpResponse.json({ message: '이미 가입된 이메일입니다.' }, { status: 409 });
+    }
+
+    const newUser: GetMyUserResponse = {
+      id: mockUsers.length + 1,
+      name: payload.name,
+      email: payload.email,
+      nickname: payload.nickname,
+      profileImageUrl: '',
+      mbti: (payload.mbti as GetMyUserResponse['mbti']) ?? '',
+      introduce: payload.introduce ?? '',
+      birthDate: payload.birthDate,
+      gender: payload.gender,
+      createdAt: new Date().toISOString(),
+    };
+
+    mockUsers.push(newUser);
+    currentUser = newUser;
+
+    return HttpResponse.json<SignUpResponse>({
+      user: newUser,
+      accessToken: MOCK_ACCESS_TOKEN,
+      refreshToken: MOCK_REFRESH_TOKEN,
     });
   }),
 

--- a/src/pages/profile/sections/account-settings/model/useAccountSettings.ts
+++ b/src/pages/profile/sections/account-settings/model/useAccountSettings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   deleteMyUser,
@@ -14,28 +14,26 @@ const EMPTY_FORM: UpdateMyUserRequest = {
   name: '',
   email: '',
   birthDate: '',
-  gender: 'ANY',
+  gender: 'MALE',
 };
 
 export const useAccountSettings = () => {
   const queryClient = useQueryClient();
   const myUserQuery = useQuery(myUserQueryOptions());
   const [form, setForm] = useState<UpdateMyUserRequest>(EMPTY_FORM);
+  const [syncedUserId, setSyncedUserId] = useState<number | null>(null);
   const [message, setMessage] = useState('');
   const [messageTone, setMessageTone] = useState<'success' | 'error'>('success');
 
-  useEffect(() => {
-    if (!myUserQuery.data) {
-      return;
-    }
-
+  if (myUserQuery.data && myUserQuery.data.id !== syncedUserId) {
+    setSyncedUserId(myUserQuery.data.id);
     setForm({
       name: myUserQuery.data.name,
       email: myUserQuery.data.email,
       birthDate: myUserQuery.data.birthDate,
       gender: myUserQuery.data.gender,
     });
-  }, [myUserQuery.data]);
+  }
 
   const updateMutation = useMutation({
     mutationFn: updateMyUser,

--- a/src/pages/profile/sections/account-settings/ui/AccountSettingsSection.tsx
+++ b/src/pages/profile/sections/account-settings/ui/AccountSettingsSection.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router';
 import { useAccountSettings } from '../model/useAccountSettings';
 
 const GENDER_OPTIONS = [
-  { value: 'ANY', label: '선택 안 함' },
   { value: 'MALE', label: '남성' },
   { value: 'FEMALE', label: '여성' },
 ] as const;
@@ -104,7 +103,7 @@ const AccountSettingsSection = () => {
 
         <div className="block">
           <span className="mb-2 block text-sm font-semibold text-slate-700">성별</span>
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 gap-2">
             {GENDER_OPTIONS.map((option) => {
               const isSelected = form.gender === option.value;
               return (

--- a/src/pages/user/index.ts
+++ b/src/pages/user/index.ts
@@ -1,1 +1,2 @@
-export { default } from '@/pages/user/ui/LoginPage';
+export { default as LoginPage } from '@/pages/user/ui/LoginPage';
+export { default as SignUpPage } from '@/pages/user/ui/SignUpPage';

--- a/src/pages/user/ui/SignUpPage.tsx
+++ b/src/pages/user/ui/SignUpPage.tsx
@@ -1,0 +1,30 @@
+import { UsersRound } from 'lucide-react';
+import { Link, useNavigate } from 'react-router';
+import SignUpForm from '@/features/auth/sign-up';
+
+const SignUpPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.18),_transparent_34%),linear-gradient(180deg,_#f8fafc_0%,_#eef2ff_100%)] px-6 py-10">
+      <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-5xl flex-col items-center justify-center gap-8">
+        <section className="w-full max-w-md text-slate-900">
+          <div className="inline-flex items-center gap-3 rounded-full border border-indigo-200/70 bg-white/80 px-4 py-2 text-sm font-medium text-indigo-600 shadow-sm backdrop-blur">
+            <UsersRound className="h-4 w-4" />
+            <Link to="/">메인페이지로 돌아가기</Link>
+          </div>
+          <h1 className="mt-6 text-4xl font-black tracking-[-0.05em] text-slate-900">
+            가입하고
+            <br />
+            점심메이트를 찾아보세요.
+          </h1>
+        </section>
+        <div className="w-full max-w-md">
+          <SignUpForm onSuccess={() => navigate('/')} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignUpPage;

--- a/src/shared/ui/auth/AuthField.tsx
+++ b/src/shared/ui/auth/AuthField.tsx
@@ -3,11 +3,12 @@ import type { ReactNode } from 'react';
 interface AuthFieldProps {
   id: string;
   label: string;
-  type: 'text' | 'email' | 'password';
+  type: 'text' | 'email' | 'password' | 'date';
   placeholder: string;
   trailing?: ReactNode;
   inputClassName?: string;
   registration: Record<string, unknown>;
+  error?: string;
 }
 
 const AuthField = ({
@@ -18,6 +19,7 @@ const AuthField = ({
   trailing,
   inputClassName = 'h-14',
   registration,
+  error,
 }: AuthFieldProps) => (
   <div className="space-y-2.5">
     <label htmlFor={id} className="text-sm font-semibold text-slate-900">
@@ -28,7 +30,11 @@ const AuthField = ({
         id={id}
         type={type}
         placeholder={placeholder}
-        className={`${inputClassName} w-full rounded-2xl border border-slate-200 bg-white px-4 ${trailing ? 'pr-12' : ''} text-base text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-indigo-300 focus:ring-4 focus:ring-indigo-100`}
+        className={`${inputClassName} w-full rounded-2xl border bg-white px-4 ${trailing ? 'pr-12' : ''} text-base text-slate-900 outline-none transition placeholder:text-slate-400 focus:ring-4 ${
+          error
+            ? 'border-red-400 focus:border-red-400 focus:ring-red-100'
+            : 'border-slate-200 focus:border-indigo-300 focus:ring-indigo-100'
+        }`}
         {...registration}
       />
       {trailing ? (
@@ -37,6 +43,7 @@ const AuthField = ({
         </span>
       ) : null}
     </div>
+    {error && <p className="pl-1 text-xs text-red-500">{error}</p>}
   </div>
 );
 

--- a/src/shared/ui/auth/AuthSubmitButton.tsx
+++ b/src/shared/ui/auth/AuthSubmitButton.tsx
@@ -1,13 +1,19 @@
+import { Loader2 } from 'lucide-react';
+
 interface AuthSubmitButtonProps {
   label: string;
+  pendingLabel?: string;
+  isPending?: boolean;
 }
 
-const AuthSubmitButton = ({ label }: AuthSubmitButtonProps) => (
+const AuthSubmitButton = ({ label, pendingLabel, isPending = false }: AuthSubmitButtonProps) => (
   <button
     type="submit"
-    className="mt-6 inline-flex h-14 w-full items-center justify-center rounded-2xl bg-indigo-500 text-base font-semibold text-white transition hover:bg-indigo-600"
+    disabled={isPending}
+    className="mt-6 inline-flex h-14 w-full items-center justify-center gap-2 rounded-2xl bg-indigo-500 text-base font-semibold text-white transition hover:bg-indigo-600 disabled:opacity-70"
   >
-    {label}
+    {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+    {isPending ? (pendingLabel ?? label) : label}
   </button>
 );
 

--- a/src/shared/ui/modal/modalLayout.tsx
+++ b/src/shared/ui/modal/modalLayout.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
 import { login, myProfileQueryOptions, myUserQueryOptions } from '@/entities/user';
 import { setAuthAccessToken } from '@/shared/lib/auth/session';
 
@@ -16,6 +17,7 @@ interface LoginInput {
 }
 
 function AuthDialog({ isOpen, onClose }: ModalProps) {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const {
     handleSubmit,
@@ -123,7 +125,15 @@ function AuthDialog({ isOpen, onClose }: ModalProps) {
         <div className="flex items-center gap-3 text-sm text-gray-500">
           <button className="underline hover:text-gray-700">비밀번호 찾기</button>
           <span className="text-gray-300">|</span>
-          <button className="underline hover:text-gray-700">회원가입</button>
+          <button
+            onClick={() => {
+              onClose();
+              navigate('/signup');
+            }}
+            className="underline hover:text-gray-700"
+          >
+            회원가입
+          </button>
           <span className="text-gray-300">|</span>
           <button className="underline hover:text-gray-700">아이디(이메일) 찾기</button>
         </div>


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- /signup 라우트 연결 및 회원가입 폼의 필드 재구성과 유효성 검사를 통해 회원가입 성공 시 자동 로그인 되도록 구현하였습니다.

## ✨ 변경 사항 (Changes)

- `/signup` 라우트 및 `SignUpPage` 생성
- 회원가입`(SignUpRequest, SignUpResponse)` 타입 추가
- `(featuresauth/sign-up/ui/SignUpForm.tsx)` 생년월일, 성별, 학교 정보, 자기소개, MBTI 필드 추가
- 회원가입 성공 시 토큰 저장 및 유저 캐시 갱신으로 자동 로그인 구현

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?
