### PR TITLE
feat: (#151) 관리자 전용 학식 삭제 기능 구현

### DIFF
--- a/src/features/lunch/delete/api.ts
+++ b/src/features/lunch/delete/api.ts
@@ -1,0 +1,5 @@
+import client from '@/shared/api/client';
+
+export async function deleteLunchMenu(menuId: number): Promise<void> {
+  await client.delete(`/api/v1/lunch-menus/${menuId}`);
+}

--- a/src/features/lunch/delete/index.ts
+++ b/src/features/lunch/delete/index.ts
@@ -1,0 +1,3 @@
+export { deleteLunchMenu } from './api';
+export { useDeleteLunchMenuAction } from './model/useDeleteLunchMenuAction';
+export { default } from './ui/DeleteLunchMenuConfirmModal';

--- a/src/features/lunch/delete/model/useDeleteLunchMenuAction.ts
+++ b/src/features/lunch/delete/model/useDeleteLunchMenuAction.ts
@@ -1,0 +1,66 @@
+import { useMutation, type QueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { useState } from 'react';
+import { lunchMenuQueryKeys, type MainLunchMenu } from '@/entities/lunch-menu';
+import { getApiMessage } from '@/shared/lib/api/getApiMessage';
+import { deleteLunchMenu } from '../api';
+
+interface UseDeleteLunchMenuActionParams {
+  targetMenu: MainLunchMenu | null;
+  queryClient: QueryClient;
+  selectedLunchMenuId: number | null;
+  setSelectedLunchMenuId: (menuId: number | null) => void;
+  closeDeleteConfirm: () => void;
+}
+
+export const useDeleteLunchMenuAction = ({
+  targetMenu,
+  queryClient,
+  selectedLunchMenuId,
+  setSelectedLunchMenuId,
+  closeDeleteConfirm,
+}: UseDeleteLunchMenuActionParams) => {
+  const [deleteErrorMessage, setDeleteErrorMessage] = useState('');
+  const deleteLunchMenuMutation = useMutation({ mutationFn: deleteLunchMenu });
+
+  const handleDeleteLunchMenu = async () => {
+    if (!targetMenu) {
+      return;
+    }
+
+    try {
+      await deleteLunchMenuMutation.mutateAsync(targetMenu.id);
+
+      queryClient.setQueryData<MainLunchMenu[]>(lunchMenuQueryKeys.lists(), (currentMenus) =>
+        (currentMenus ?? []).filter((menu) => menu.id !== targetMenu.id),
+      );
+
+      if (selectedLunchMenuId === targetMenu.id) {
+        setSelectedLunchMenuId(null);
+      }
+
+      setDeleteErrorMessage('');
+      closeDeleteConfirm();
+      await queryClient.invalidateQueries({ queryKey: lunchMenuQueryKeys.lists() });
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        setDeleteErrorMessage('로그인 후 이용할 수 있어요.');
+        return;
+      }
+
+      if (isAxiosError(error) && error.response?.status === 403) {
+        setDeleteErrorMessage('관리자만 메뉴를 삭제할 수 있어요.');
+        return;
+      }
+
+      setDeleteErrorMessage(getApiMessage(error, '메뉴를 삭제하지 못했어요.'));
+    }
+  };
+
+  return {
+    deleteErrorMessage,
+    setDeleteErrorMessage,
+    handleDeleteLunchMenu,
+    isDeleteLunchMenuPending: deleteLunchMenuMutation.isPending,
+  };
+};

--- a/src/features/lunch/delete/ui/DeleteLunchMenuConfirmModal.tsx
+++ b/src/features/lunch/delete/ui/DeleteLunchMenuConfirmModal.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+
+interface DeleteLunchMenuConfirmModalProps {
+  isOpen: boolean;
+  isPending: boolean;
+  errorMessage: string;
+  menuName?: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const DeleteLunchMenuConfirmModal = ({
+  isOpen,
+  isPending,
+  errorMessage,
+  menuName,
+  onClose,
+  onConfirm,
+}: DeleteLunchMenuConfirmModalProps) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialogElement = dialogRef.current;
+
+    if (!dialogElement) {
+      return;
+    }
+
+    if (isOpen && !dialogElement.open) {
+      dialogElement.showModal();
+      return;
+    }
+
+    if (!isOpen && dialogElement.open) {
+      dialogElement.close();
+    }
+  }, [isOpen]);
+
+  const handleDialogClick = (event: React.MouseEvent<HTMLDialogElement>) => {
+    if (event.target === dialogRef.current && !isPending) {
+      onClose();
+    }
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      onClick={handleDialogClick}
+      className="m-auto backdrop:bg-slate-950/50 w-full max-w-lg rounded-[32px] bg-white p-0 text-left shadow-[0_24px_80px_rgba(15,23,42,0.22)] backdrop:backdrop-blur-[2px]"
+    >
+      <div className="p-6 md:p-7">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-rose-50 text-rose-500">
+              <AlertTriangle className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-rose-500">학식 메뉴 삭제</p>
+              <h2 className="mt-1 text-[24px] font-bold tracking-[-0.03em] text-slate-900">
+                {menuName ? `'${menuName}' 메뉴를 삭제할까요?` : '이 메뉴를 삭제할까요?'}
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-slate-500">삭제 후 되돌릴 수 없어요.</p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-100 text-slate-500 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {errorMessage ? (
+          <p className="mt-5 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-600">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col-reverse gap-3 md:flex-row md:justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+            className="rounded-2xl border border-slate-200 px-5 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isPending}
+            className="rounded-2xl bg-rose-500 px-5 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(244,63,94,0.25)] transition hover:bg-rose-600 disabled:cursor-not-allowed disabled:bg-rose-300"
+          >
+            {isPending ? '삭제 중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+};
+
+export default DeleteLunchMenuConfirmModal;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1397,4 +1397,21 @@ export const handlers = [
 
     return HttpResponse.json(updated);
   }),
+
+  http.delete('/api/v1/lunch-menus/:menuId', async ({ request, params }) => {
+    await wait();
+    if (!isAuthorized(request)) return unauthorizedResponse();
+    if (!isAdminAuthorized(request)) return forbiddenResponse();
+
+    const menuId = Number(params.menuId);
+    const existingMenu = lunchMenus.find((menu) => menu.id === menuId);
+
+    if (!existingMenu) {
+      return HttpResponse.json({ message: '메뉴를 찾을 수 없어요.' }, { status: 404 });
+    }
+
+    lunchMenus = lunchMenus.filter((menu) => menu.id !== menuId);
+
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];

--- a/src/widgets/lunch-section/ui/LunchMenuCard.tsx
+++ b/src/widgets/lunch-section/ui/LunchMenuCard.tsx
@@ -1,4 +1,4 @@
-import { Flame, PencilLine, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { Flame, PencilLine, ThumbsDown, ThumbsUp, Trash2 } from 'lucide-react';
 import { cn } from '@/shared/lib/classnames';
 import { lunchMealTypeLabelMap, type MainLunchMenu } from '../model/types';
 
@@ -10,9 +10,17 @@ interface LunchMenuCardProps {
   onSelect: (menuId: number) => void;
   isAdmin?: boolean;
   onEdit?: (menu: MainLunchMenu) => void;
+  onDelete?: (menu: MainLunchMenu) => void;
 }
 
-const LunchMenuCard = ({ menu, isSelected, onSelect, isAdmin, onEdit }: LunchMenuCardProps) => (
+const LunchMenuCard = ({
+  menu,
+  isSelected,
+  onSelect,
+  isAdmin,
+  onEdit,
+  onDelete,
+}: LunchMenuCardProps) => (
   <article
     onClick={() => onSelect(menu.id)}
     className={cn(
@@ -38,6 +46,20 @@ const LunchMenuCard = ({ menu, isSelected, onSelect, isAdmin, onEdit }: LunchMen
               className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-slate-100 text-slate-500 transition hover:bg-slate-200"
             >
               <PencilLine className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+          {isAdmin ? (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onDelete?.(menu);
+              }}
+              aria-label="메뉴 삭제"
+              title="메뉴 삭제"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-slate-100 text-slate-500 transition hover:bg-rose-100 hover:text-rose-600"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
             </button>
           ) : null}
         </div>

--- a/src/widgets/lunch-section/ui/LunchSection.tsx
+++ b/src/widgets/lunch-section/ui/LunchSection.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import LunchMenuEditorModal, { type LunchMenuEditorFormValues } from '@/features/lunch/editor';
+import DeleteLunchMenuConfirmModal, { useDeleteLunchMenuAction } from '@/features/lunch/delete';
 import { useLunchSelection } from '../model/useLunchSelection';
 import type { MainLunchMenu } from '../model/types';
 import LunchMenuCard from './LunchMenuCard';
@@ -23,12 +25,22 @@ const toEditorFormValues = (menu: MainLunchMenu): LunchMenuEditorFormValues => (
 });
 
 const LunchSection = ({ lunchMenus, isAdmin, onLike, onDislike }: LunchSectionProps) => {
+  const queryClient = useQueryClient();
   const { selectedLunchMenuId, setSelectedLunchMenuId, selectedLunchMenu } = useLunchSelection({
     lunchMenus,
   });
   const [editorTarget, setEditorTarget] = useState<MainLunchMenu | 'create' | null>(null);
   const isEditorOpen = editorTarget !== null;
   const isEditMode = editorTarget !== null && editorTarget !== 'create';
+
+  const [deleteTarget, setDeleteTarget] = useState<MainLunchMenu | null>(null);
+  const deleteAction = useDeleteLunchMenuAction({
+    targetMenu: deleteTarget,
+    queryClient,
+    selectedLunchMenuId,
+    setSelectedLunchMenuId,
+    closeDeleteConfirm: () => setDeleteTarget(null),
+  });
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -58,6 +70,7 @@ const LunchSection = ({ lunchMenus, isAdmin, onLike, onDislike }: LunchSectionPr
           onSelect={setSelectedLunchMenuId}
           isAdmin={isAdmin}
           onEdit={setEditorTarget}
+          onDelete={setDeleteTarget}
         />
       ))}
 
@@ -71,6 +84,18 @@ const LunchSection = ({ lunchMenus, isAdmin, onLike, onDislike }: LunchSectionPr
         mode={isEditMode ? 'edit' : 'create'}
         menuId={isEditMode ? editorTarget.id : undefined}
         initialValues={isEditMode ? toEditorFormValues(editorTarget) : undefined}
+      />
+
+      <DeleteLunchMenuConfirmModal
+        isOpen={deleteTarget !== null}
+        isPending={deleteAction.isDeleteLunchMenuPending}
+        errorMessage={deleteAction.deleteErrorMessage}
+        menuName={deleteTarget?.menuName}
+        onClose={() => {
+          setDeleteTarget(null);
+          deleteAction.setDeleteErrorMessage('');
+        }}
+        onConfirm={deleteAction.handleDeleteLunchMenu}
       />
     </section>
   );


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 관리자 계정 전용 학식 메뉴를 삭제할 수 있는 기능을 구현했습니다.

## ✨ 변경 사항 (Changes)

- 학식 메뉴 카드에 관리자 전용 삭제 버튼 추가
- 삭제 확인 모달 및 삭제 API 연동
- 삭제 성공/실패 처리 및 목록 캐시 갱신
- DELETE /api/v1/lunch-menus/:menuId MSW 목업 핸들러 추가

## 📸 스크린샷 (Screenshots)

- 스크린샷 첨부

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?
