### PR TITLE
refactor: (#153) 사용자 프로필 이미지 업데이트 방식 수정

### DIFF
--- a/src/entities/user/api/profileImage.ts
+++ b/src/entities/user/api/profileImage.ts
@@ -1,0 +1,18 @@
+import client from '@/shared/api/client';
+
+export interface UploadMyProfileImageResponse {
+  profileImageUrl: string;
+}
+
+export async function uploadMyProfileImage(file: File): Promise<UploadMyProfileImageResponse> {
+  const formData = new FormData();
+  formData.append('image', file);
+
+  const response = await client.post<UploadMyProfileImageResponse>(
+    '/api/v1/users/me/profile-image',
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } },
+  );
+
+  return response.data;
+}

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -2,6 +2,7 @@ export { login, logout, signup } from './api/auth';
 export { deleteMyUser, getMyUser, updateMyUser } from './api/me';
 export { myUserQueryOptions } from './api/meQueries';
 export { getMyProfile, updateMyProfile } from './api/profile';
+export { uploadMyProfileImage } from './api/profileImage';
 export { myProfileQueryOptions } from './api/profileQueries';
 export { MBTI_OPTIONS } from './model/profile';
 export type {

--- a/src/entities/user/ui/ProfileAvatar.tsx
+++ b/src/entities/user/ui/ProfileAvatar.tsx
@@ -21,7 +21,7 @@ const ProfileAvatar = ({
     <button
       type="button"
       onClick={onClick}
-      aria-label="프로필 이미지 URL 수정"
+      aria-label="프로필 이미지 수정"
       className="flex h-28 w-28 items-center justify-center overflow-hidden rounded-full bg-slate-100 text-sm font-semibold text-slate-500 shadow-sm transition hover:scale-[1.02] hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-200 sm:h-32 sm:w-32"
     >
       {showProfileImage ? (

--- a/src/features/profile/update/model/useProfileEditor.ts
+++ b/src/features/profile/update/model/useProfileEditor.ts
@@ -16,7 +16,6 @@ export const useProfileEditor = () => {
   const save = useProfileSave({
     profile: draft.profile,
     setProfileDraft: draft.setProfileDraft,
-    setImageInputValue: imageEditor.setImageInputValue,
     setImageError: imageEditor.setImageError,
   });
 
@@ -26,18 +25,17 @@ export const useProfileEditor = () => {
     isError: profileQuery.isError,
     error: profileQuery.error,
     refetch: profileQuery.refetch,
-    imageInputValue: imageEditor.imageInputValue,
-    isImageEditorOpen: imageEditor.isImageEditorOpen,
     imageError: imageEditor.imageError,
+    fileInputRef: imageEditor.fileInputRef,
+    isUploadPending: imageEditor.isUploadPending,
+    uploadErrorMessage: imageEditor.uploadErrorMessage,
     saveMessage: save.saveMessage,
     saveMessageTone: save.saveMessageTone,
     isSavePending: save.isSavePending,
-    setImageInputValue: imageEditor.setImageInputValue,
     setImageError: imageEditor.setImageError,
     handleFieldChange: draft.handleFieldChange,
-    handleImageApply: imageEditor.handleImageApply,
-    handleImageEditorToggle: imageEditor.handleImageEditorToggle,
-    handleImageEditorClose: imageEditor.handleImageEditorClose,
+    handleImageButtonClick: imageEditor.handleImageButtonClick,
+    handleImageFileChange: imageEditor.handleImageFileChange,
     handleSave: save.handleSave,
   };
 };

--- a/src/features/profile/update/model/useProfileImageEditor.ts
+++ b/src/features/profile/update/model/useProfileImageEditor.ts
@@ -1,5 +1,6 @@
-import { useState } from 'react';
-import type { UserProfile } from '@/entities/user';
+import { useMutation } from '@tanstack/react-query';
+import { useRef, useState, type ChangeEvent } from 'react';
+import { uploadMyProfileImage, type UserProfile } from '@/entities/user';
 
 interface UseProfileImageEditorParams {
   profile: UserProfile;
@@ -10,42 +11,41 @@ export const useProfileImageEditor = ({
   profile,
   setProfileDraft,
 }: UseProfileImageEditorParams) => {
-  const [imageInputValue, setImageInputValue] = useState('');
-  const [isImageEditorOpen, setIsImageEditorOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [imageError, setImageError] = useState(false);
 
-  const handleImageApply = () => {
-    const nextImageUrl = imageInputValue.trim();
-    setImageError(false);
-    setProfileDraft((current) => ({ ...profile, ...current, profileImageUrl: nextImageUrl }));
-    if (!nextImageUrl) {
-      setIsImageEditorOpen(false);
+  const uploadMutation = useMutation({
+    mutationFn: uploadMyProfileImage,
+    onSuccess: ({ profileImageUrl }) => {
+      setImageError(false);
+      setProfileDraft((current) => ({ ...profile, ...current, profileImageUrl }));
+    },
+  });
+
+  const handleImageButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImageFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+
+    if (!file) {
+      return;
     }
-  };
 
-  const handleImageEditorToggle = () => {
-    setIsImageEditorOpen((current) => {
-      const nextOpen = !current;
-      if (nextOpen) {
-        setImageInputValue(profile.profileImageUrl);
-      }
-      return nextOpen;
-    });
-  };
-
-  const handleImageEditorClose = () => {
-    setImageInputValue(profile.profileImageUrl);
-    setIsImageEditorOpen(false);
+    uploadMutation.mutate(file);
   };
 
   return {
-    imageInputValue,
-    setImageInputValue,
-    isImageEditorOpen,
+    fileInputRef,
     imageError,
     setImageError,
-    handleImageApply,
-    handleImageEditorToggle,
-    handleImageEditorClose,
+    isUploadPending: uploadMutation.isPending,
+    uploadErrorMessage: uploadMutation.isError
+      ? '이미지 업로드에 실패했어요. 다시 시도해 주세요.'
+      : '',
+    handleImageButtonClick,
+    handleImageFileChange,
   };
 };

--- a/src/features/profile/update/model/useProfileSave.ts
+++ b/src/features/profile/update/model/useProfileSave.ts
@@ -11,14 +11,12 @@ import { normalizeProfile } from './normalizeProfile';
 interface UseProfileSaveParams {
   profile: UserProfile;
   setProfileDraft: React.Dispatch<React.SetStateAction<UserProfile | null>>;
-  setImageInputValue: (value: string) => void;
   setImageError: (value: boolean) => void;
 }
 
 export const useProfileSave = ({
   profile,
   setProfileDraft,
-  setImageInputValue,
   setImageError,
 }: UseProfileSaveParams) => {
   const queryClient = useQueryClient();
@@ -30,7 +28,6 @@ export const useProfileSave = ({
     onSuccess: (updatedProfile) => {
       const normalizedUpdatedProfile = normalizeProfile(updatedProfile);
       setProfileDraft(normalizedUpdatedProfile);
-      setImageInputValue(normalizedUpdatedProfile.profileImageUrl);
       setImageError(false);
       setSaveMessage('프로필이 저장되었어요.');
       setSaveMessageTone('success');

--- a/src/features/profile/update/ui/ProfileImageEditor.tsx
+++ b/src/features/profile/update/ui/ProfileImageEditor.tsx
@@ -1,56 +1,29 @@
+import type { ChangeEvent, RefObject } from 'react';
+
 interface ProfileImageEditorProps {
-  isOpen: boolean;
-  imageInputValue: string;
-  imageError: boolean;
-  onImageInputChange: (value: string) => void;
-  onApply: () => void;
-  onClose: () => void;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  isUploadPending: boolean;
+  uploadErrorMessage: string;
+  onFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 const ProfileImageEditor = ({
-  isOpen,
-  imageInputValue,
-  imageError,
-  onImageInputChange,
-  onApply,
-  onClose,
-}: ProfileImageEditorProps) => {
-  if (!isOpen) {
-    return null;
-  }
-
-  return (
-    <div className="w-full max-w-xs space-y-2">
-      <input
-        type="url"
-        value={imageInputValue}
-        onChange={(event) => onImageInputChange(event.target.value)}
-        placeholder="이미지 URL을 입력하세요"
-        className="h-12 w-full rounded-2xl border border-slate-100 bg-slate-50 px-4 text-sm text-slate-700 outline-none transition placeholder:text-slate-400 focus:border-indigo-200 focus:bg-white"
-      />
-      <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={onApply}
-          className="h-11 flex-1 rounded-2xl bg-slate-900 px-4 text-sm font-medium text-white transition hover:bg-slate-800"
-        >
-          적용
-        </button>
-        <button
-          type="button"
-          onClick={onClose}
-          className="h-11 flex-1 rounded-2xl border border-slate-200 bg-white px-4 text-sm font-medium text-slate-600 transition hover:bg-slate-50"
-        >
-          취소
-        </button>
-      </div>
-      {imageError ? (
-        <p className="text-xs text-rose-500">
-          이미지를 불러오지 못했어요. 다른 URL을 입력하면 다시 시도합니다.
-        </p>
-      ) : null}
-    </div>
-  );
-};
+  fileInputRef,
+  isUploadPending,
+  uploadErrorMessage,
+  onFileChange,
+}: ProfileImageEditorProps) => (
+  <div className="flex flex-col items-center gap-1 sm:items-start">
+    <input
+      ref={fileInputRef}
+      type="file"
+      accept="image/*"
+      className="hidden"
+      onChange={onFileChange}
+    />
+    {isUploadPending ? <p className="text-xs font-medium text-slate-400">업로드 중...</p> : null}
+    {uploadErrorMessage ? <p className="text-xs text-rose-500">{uploadErrorMessage}</p> : null}
+  </div>
+);
 
 export default ProfileImageEditor;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -984,6 +984,24 @@ export const handlers = [
     return HttpResponse.json(profile);
   }),
 
+  http.post('/api/v1/users/me/profile-image', async ({ request }) => {
+    await wait();
+    if (!isAuthorized(request)) {
+      return unauthorizedResponse();
+    }
+
+    const formData = await request.formData();
+    const file = formData.get('image');
+
+    if (!(file instanceof File)) {
+      return HttpResponse.json({ message: '이미지 파일이 필요해요.' }, { status: 400 });
+    }
+
+    const profileImageUrl = URL.createObjectURL(file);
+
+    return HttpResponse.json({ profileImageUrl });
+  }),
+
   http.get('/api/v1/friends', async ({ request }) => {
     await wait();
     if (!isAuthorized(request)) {

--- a/src/pages/profile/sections/profile-editor/ui/ProfileEditorHero.tsx
+++ b/src/pages/profile/sections/profile-editor/ui/ProfileEditorHero.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent, RefObject } from 'react';
 import { ProfileAvatar } from '@/entities/user';
 import { ProfileImageEditor } from '@/features/profile/update';
 import type { UserProfile } from '@/entities/user';
@@ -5,27 +6,25 @@ import type { UserProfile } from '@/entities/user';
 interface ProfileEditorHeroProps {
   profile: UserProfile;
   displayNickname: string;
-  imageInputValue: string;
-  isImageEditorOpen: boolean;
   imageError: boolean;
-  setImageInputValue: (value: string) => void;
   setImageError: (value: boolean) => void;
-  onImageApply: () => void;
-  onImageEditorToggle: () => void;
-  onImageEditorClose: () => void;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  isUploadPending: boolean;
+  uploadErrorMessage: string;
+  onImageButtonClick: () => void;
+  onImageFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 const ProfileEditorHero = ({
   profile,
   displayNickname,
-  imageInputValue,
-  isImageEditorOpen,
   imageError,
-  setImageInputValue,
   setImageError,
-  onImageApply,
-  onImageEditorToggle,
-  onImageEditorClose,
+  fileInputRef,
+  isUploadPending,
+  uploadErrorMessage,
+  onImageButtonClick,
+  onImageFileChange,
 }: ProfileEditorHeroProps) => (
   <div className="flex flex-col gap-6 sm:flex-row sm:items-center">
     <div className="flex flex-col items-center gap-3 sm:items-start">
@@ -34,16 +33,14 @@ const ProfileEditorHero = ({
         profileImageUrl={profile.profileImageUrl}
         imageError={imageError}
         onError={() => setImageError(true)}
-        onClick={onImageEditorToggle}
+        onClick={onImageButtonClick}
       />
-      <span className="text-xs font-medium text-slate-400">이미지를 클릭해 URL 변경</span>
+      <span className="text-xs font-medium text-slate-400">이미지를 클릭해 사진 변경</span>
       <ProfileImageEditor
-        isOpen={isImageEditorOpen}
-        imageInputValue={imageInputValue}
-        imageError={imageError}
-        onImageInputChange={setImageInputValue}
-        onApply={onImageApply}
-        onClose={onImageEditorClose}
+        fileInputRef={fileInputRef}
+        isUploadPending={isUploadPending}
+        uploadErrorMessage={uploadErrorMessage}
+        onFileChange={onImageFileChange}
       />
     </div>
 

--- a/src/pages/profile/sections/profile-editor/ui/ProfileEditorSection.tsx
+++ b/src/pages/profile/sections/profile-editor/ui/ProfileEditorSection.tsx
@@ -10,18 +10,17 @@ const ProfileEditorSection = () => {
     isError,
     error,
     refetch,
-    imageInputValue,
-    isImageEditorOpen,
     imageError,
+    fileInputRef,
+    isUploadPending,
+    uploadErrorMessage,
     saveMessage,
     saveMessageTone,
     isSavePending,
-    setImageInputValue,
     setImageError,
     handleFieldChange,
-    handleImageApply,
-    handleImageEditorToggle,
-    handleImageEditorClose,
+    handleImageButtonClick,
+    handleImageFileChange,
     handleSave,
   } = useProfileEditor();
 
@@ -43,14 +42,13 @@ const ProfileEditorSection = () => {
       <ProfileEditorHero
         profile={profile}
         displayNickname={displayNickname}
-        imageInputValue={imageInputValue}
-        isImageEditorOpen={isImageEditorOpen}
         imageError={imageError}
-        setImageInputValue={setImageInputValue}
         setImageError={setImageError}
-        onImageApply={handleImageApply}
-        onImageEditorToggle={handleImageEditorToggle}
-        onImageEditorClose={handleImageEditorClose}
+        fileInputRef={fileInputRef}
+        isUploadPending={isUploadPending}
+        uploadErrorMessage={uploadErrorMessage}
+        onImageButtonClick={handleImageButtonClick}
+        onImageFileChange={handleImageFileChange}
       />
       <ProfileEditorForm
         profile={profile}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 프로필 이미지 수정 방식을 URL 직업 입력하는 방식에서 파일 업로드 방식으로 수정했습니다.

## ✨ 변경 사항 (Changes)

- 이미지 업로드 API 추가
- useProfileImageEditor의 URL 입력 방식을 form-data를 통해 파일을 업로드하는 방식으로 수정
- 응답 받은 업로드 결과 URL을 프로필 draft에 반영
- 업로드 API 목업 핸들러 추가

## 📸 스크린샷 (Screenshots)

- 스크린샷 첨부

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?
