### PR TITLE
feat: (#164) 친구 API 연동 및 유저 검색 기능 추가

### DIFF
--- a/src/entities/friend/api/friendQueries.ts
+++ b/src/entities/friend/api/friendQueries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from '@tanstack/react-query';
-import { getFriendRequests, getFriends } from './friends';
+import { getFriendRequests, getFriends, searchUsers } from './friends';
 
 export const friendsQueryOptions = () =>
   queryOptions({
@@ -11,4 +11,11 @@ export const friendRequestsQueryOptions = () =>
   queryOptions({
     queryKey: ['friendRequests'],
     queryFn: getFriendRequests,
+  });
+
+export const userSearchQueryOptions = (keyword: string) =>
+  queryOptions({
+    queryKey: ['userSearch', keyword],
+    queryFn: () => searchUsers(keyword),
+    enabled: keyword.trim().length > 0,
   });

--- a/src/entities/friend/api/friends.ts
+++ b/src/entities/friend/api/friends.ts
@@ -4,7 +4,8 @@ import type {
   CreateFriendRequestResponse,
   GetFriendRequestsResponse,
   GetFriendsResponse,
-  RespondFriendRequestRequest,
+  RespondFriendRequestResponse,
+  SearchUsersResponse,
 } from '../model/types';
 
 export async function getFriends(): Promise<GetFriendsResponse> {
@@ -19,25 +20,49 @@ export async function getFriendRequests(): Promise<GetFriendRequestsResponse> {
   return response.data;
 }
 
-export async function createFriendRequest(
-  payload: CreateFriendRequestRequest,
-): Promise<CreateFriendRequestResponse> {
-  const response = await client.post<CreateFriendRequestResponse>('/api/v1/friends/requests', payload);
+export async function searchUsers(keyword: string): Promise<SearchUsersResponse> {
+  const response = await client.get<SearchUsersResponse>('/api/v1/users/search', {
+    params: { keyword },
+  });
 
   return response.data;
 }
 
-export async function respondFriendRequest(
-  requestId: number,
-  payload: RespondFriendRequestRequest,
-): Promise<void> {
-  await client.patch(`/api/v1/friends/requests/${requestId}`, payload);
+export async function createFriendRequest(
+  payload: CreateFriendRequestRequest,
+): Promise<CreateFriendRequestResponse> {
+  const response = await client.post<CreateFriendRequestResponse>(
+    '/api/v1/friends/requests',
+    payload,
+  );
+
+  return response.data;
 }
 
-export async function cancelFriendRequest(requestId: number): Promise<void> {
-  await client.delete(`/api/v1/friends/requests/${requestId}`);
+export async function acceptFriendRequest(
+  friendshipId: number,
+): Promise<RespondFriendRequestResponse> {
+  const response = await client.patch<RespondFriendRequestResponse>(
+    `/api/v1/friends/requests/${friendshipId}/accept`,
+  );
+
+  return response.data;
 }
 
-export async function deleteFriend(friendId: number): Promise<void> {
-  await client.delete(`/api/v1/friends/${friendId}`);
+export async function rejectFriendRequest(
+  friendshipId: number,
+): Promise<RespondFriendRequestResponse> {
+  const response = await client.patch<RespondFriendRequestResponse>(
+    `/api/v1/friends/requests/${friendshipId}/reject`,
+  );
+
+  return response.data;
+}
+
+export async function cancelFriendRequest(friendshipId: number): Promise<void> {
+  await client.delete(`/api/v1/friends/requests/${friendshipId}`);
+}
+
+export async function deleteFriend(friendshipId: number): Promise<void> {
+  await client.delete(`/api/v1/friends/${friendshipId}`);
 }

--- a/src/entities/friend/index.ts
+++ b/src/entities/friend/index.ts
@@ -1,18 +1,28 @@
 export {
+  acceptFriendRequest,
   cancelFriendRequest,
   createFriendRequest,
   deleteFriend,
   getFriendRequests,
   getFriends,
-  respondFriendRequest,
+  rejectFriendRequest,
+  searchUsers,
 } from './api/friends';
-export { friendRequestsQueryOptions, friendsQueryOptions } from './api/friendQueries';
+export {
+  friendRequestsQueryOptions,
+  friendsQueryOptions,
+  userSearchQueryOptions,
+} from './api/friendQueries';
 export type {
   CreateFriendRequestRequest,
   CreateFriendRequestResponse,
+  FriendRequestDirection,
   FriendRequestItem,
   FriendSummary,
   GetFriendRequestsResponse,
   GetFriendsResponse,
-  RespondFriendRequestRequest,
+  RelationshipStatus,
+  RespondFriendRequestResponse,
+  SearchUsersResponse,
+  UserSearchResultItem,
 } from './model/types';

--- a/src/entities/friend/model/types.ts
+++ b/src/entities/friend/model/types.ts
@@ -1,24 +1,43 @@
-export interface FriendSummary {
+import type { PublicUser } from '@/entities/user';
+
+export type RelationshipStatus =
+  | 'NONE'
+  | 'PENDING_SENT'
+  | 'PENDING_RECEIVED'
+  | 'ACCEPTED'
+  | 'REJECTED';
+
+export interface UserSearchResultItem {
   id: number;
   nickname: string;
-  mbti: string;
-  introduce: string;
-  profileImageUrl: string;
+  profileImageUrl: string | null;
+  schoolInfo: string | null;
+  relationshipStatus: RelationshipStatus;
 }
 
-export interface FriendRequestItem {
-  id: number;
-  fromUserId: number;
-  toUserId: number;
-  senderNickname: string;
-  receiverNickname: string;
-  createdAt: string;
-  direction: 'INCOMING' | 'OUTGOING';
-  status: 'PENDING';
+export interface SearchUsersResponse {
+  items: UserSearchResultItem[];
+}
+
+export interface FriendSummary {
+  friendshipId: number;
+  status: 'ACCEPTED';
+  user: PublicUser;
 }
 
 export interface GetFriendsResponse {
   items: FriendSummary[];
+}
+
+export type FriendRequestDirection = 'SENT' | 'RECEIVED';
+
+export interface FriendRequestItem {
+  friendshipId: number;
+  requesterId: number;
+  receiverId: number;
+  direction: FriendRequestDirection;
+  user: PublicUser;
+  createdAt: string;
 }
 
 export interface GetFriendRequestsResponse {
@@ -26,11 +45,21 @@ export interface GetFriendRequestsResponse {
 }
 
 export interface CreateFriendRequestRequest {
-  target: string;
+  receiverId: number;
 }
 
-export type CreateFriendRequestResponse = FriendRequestItem;
+export interface CreateFriendRequestResponse {
+  id: number;
+  requesterId: number;
+  receiverId: number;
+  status: 'PENDING';
+  createdAt: string;
+}
 
-export interface RespondFriendRequestRequest {
-  accepted: boolean;
+export interface RespondFriendRequestResponse {
+  id: number;
+  requesterId: number;
+  receiverId: number;
+  status: 'ACCEPTED' | 'REJECTED';
+  createdAt: string;
 }

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -14,6 +14,7 @@ export type {
   LoginRequest,
   LoginResponse,
   LogoutResponse,
+  PublicUser,
   SocialProvider,
   SocialRegisterRequest,
   SocialRegisterResponse,

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -19,6 +19,18 @@ export interface User {
 
 export type GetMyUserResponse = User;
 
+export interface PublicUser {
+  id: number;
+  nickname: string;
+  birthDate: string;
+  gender: Gender;
+  schoolInfo: string | null;
+  introduce: string | null;
+  mbti: MbtiType | null;
+  createdAt: string;
+  profileImageUrl: string | null;
+}
+
 export interface SignUpRequest {
   email: string;
   password: string;

--- a/src/features/friend/manage/model/useFriendManager.ts
+++ b/src/features/friend/manage/model/useFriendManager.ts
@@ -114,7 +114,7 @@ export const useFriendManager = () => {
     keyword,
     handleKeywordChange: setKeyword,
     searchResults: searchQuery.data?.items ?? [],
-    isSearching: searchQuery.isFetching,
+    isSearching: keyword.trim() !== debouncedKeyword || searchQuery.isFetching,
     feedback,
     feedbackTone,
     isCreatingRequestId: createMutation.isPending ? createMutation.variables?.receiverId : null,

--- a/src/features/friend/manage/model/useFriendManager.ts
+++ b/src/features/friend/manage/model/useFriendManager.ts
@@ -1,33 +1,46 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  acceptFriendRequest,
   cancelFriendRequest,
   createFriendRequest,
   deleteFriend,
   friendRequestsQueryOptions,
   friendsQueryOptions,
-  respondFriendRequest,
+  rejectFriendRequest,
+  userSearchQueryOptions,
 } from '@/entities/friend';
+
+const SEARCH_DEBOUNCE_MS = 350;
 
 export const useFriendManager = () => {
   const queryClient = useQueryClient();
   const friendsQuery = useQuery(friendsQueryOptions());
   const requestsQuery = useQuery(friendRequestsQueryOptions());
-  const [target, setTarget] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [debouncedKeyword, setDebouncedKeyword] = useState('');
   const [feedback, setFeedback] = useState('');
   const [feedbackTone, setFeedbackTone] = useState<'success' | 'error'>('success');
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedKeyword(keyword.trim()), SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [keyword]);
+
+  const searchQuery = useQuery(userSearchQueryOptions(debouncedKeyword));
 
   const refreshFriendData = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: friendsQueryOptions().queryKey }),
       queryClient.invalidateQueries({ queryKey: friendRequestsQueryOptions().queryKey }),
+      queryClient.invalidateQueries({ queryKey: ['userSearch'] }),
     ]);
   };
 
   const createMutation = useMutation({
     mutationFn: createFriendRequest,
     onSuccess: async () => {
-      setTarget('');
       setFeedback('친구 신청을 보냈어요.');
       setFeedbackTone('success');
       await refreshFriendData();
@@ -38,16 +51,28 @@ export const useFriendManager = () => {
     },
   });
 
-  const respondMutation = useMutation({
-    mutationFn: ({ requestId, accepted }: { requestId: number; accepted: boolean }) =>
-      respondFriendRequest(requestId, { accepted }),
-    onSuccess: async (_, variables) => {
-      setFeedback(variables.accepted ? '친구 신청을 수락했어요.' : '친구 신청을 거절했어요.');
+  const acceptMutation = useMutation({
+    mutationFn: acceptFriendRequest,
+    onSuccess: async () => {
+      setFeedback('친구 신청을 수락했어요.');
       setFeedbackTone('success');
       await refreshFriendData();
     },
     onError: () => {
-      setFeedback('친구 신청 처리에 실패했어요.');
+      setFeedback('친구 신청 수락에 실패했어요.');
+      setFeedbackTone('error');
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: rejectFriendRequest,
+    onSuccess: async () => {
+      setFeedback('친구 신청을 거절했어요.');
+      setFeedbackTone('success');
+      await refreshFriendData();
+    },
+    onError: () => {
+      setFeedback('친구 신청 거절에 실패했어요.');
       setFeedbackTone('error');
     },
   });
@@ -78,32 +103,25 @@ export const useFriendManager = () => {
     },
   });
 
-  const handleSubmitRequest = () => {
-    if (!target.trim()) {
-      setFeedback('닉네임 또는 이메일을 입력해 주세요.');
-      setFeedbackTone('error');
-      return;
-    }
-
-    createMutation.mutate({
-      target: target.trim(),
-    });
-  };
+  const requests = requestsQuery.data?.items ?? [];
 
   return {
     friends: friendsQuery.data?.items ?? [],
-    requests: requestsQuery.data?.items ?? [],
+    receivedRequests: requests.filter((item) => item.direction === 'RECEIVED'),
+    sentRequests: requests.filter((item) => item.direction === 'SENT'),
     isLoading: friendsQuery.isLoading || requestsQuery.isLoading,
     isError: friendsQuery.isError || requestsQuery.isError,
-    target,
+    keyword,
+    handleKeywordChange: setKeyword,
+    searchResults: searchQuery.data?.items ?? [],
+    isSearching: searchQuery.isFetching,
     feedback,
     feedbackTone,
-    isCreating: createMutation.isPending,
-    handleTargetChange: setTarget,
-    handleSubmitRequest,
-    handleAccept: (requestId: number) => respondMutation.mutate({ requestId, accepted: true }),
-    handleReject: (requestId: number) => respondMutation.mutate({ requestId, accepted: false }),
-    handleCancel: (requestId: number) => cancelMutation.mutate(requestId),
-    handleDeleteFriend: (friendId: number) => deleteMutation.mutate(friendId),
+    isCreatingRequestId: createMutation.isPending ? createMutation.variables?.receiverId : null,
+    handleSendRequest: (receiverId: number) => createMutation.mutate({ receiverId }),
+    handleAccept: (friendshipId: number) => acceptMutation.mutate(friendshipId),
+    handleReject: (friendshipId: number) => rejectMutation.mutate(friendshipId),
+    handleCancel: (friendshipId: number) => cancelMutation.mutate(friendshipId),
+    handleDeleteFriend: (friendshipId: number) => deleteMutation.mutate(friendshipId),
   };
 };

--- a/src/features/friend/manage/ui/FriendAvatar.tsx
+++ b/src/features/friend/manage/ui/FriendAvatar.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+interface FriendAvatarProps {
+  nickname: string;
+  profileImageUrl: string | null;
+  size?: 'sm' | 'md';
+}
+
+const FriendAvatar = ({ nickname, profileImageUrl, size = 'md' }: FriendAvatarProps) => {
+  const [imageError, setImageError] = useState(false);
+  const displayNickname = nickname.trim() || '익명 사용자';
+  const showImage = Boolean(profileImageUrl) && !imageError;
+  const sizeClassName = size === 'sm' ? 'h-10 w-10 text-sm' : 'h-12 w-12 text-base';
+
+  return (
+    <div
+      className={`flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-slate-100 font-semibold text-slate-500 ${sizeClassName}`}
+    >
+      {showImage ? (
+        <img
+          src={profileImageUrl ?? undefined}
+          alt={`${displayNickname} profile`}
+          className="h-full w-full object-cover"
+          onError={() => setImageError(true)}
+        />
+      ) : (
+        <span>{displayNickname.charAt(0).toUpperCase()}</span>
+      )}
+    </div>
+  );
+};
+
+export default FriendAvatar;

--- a/src/features/friend/manage/ui/FriendManagerSection.tsx
+++ b/src/features/friend/manage/ui/FriendManagerSection.tsx
@@ -1,26 +1,74 @@
-import { MailPlus, UserMinus, Users } from 'lucide-react';
+import { Search, UserMinus, Users } from 'lucide-react';
+import type { RelationshipStatus, UserSearchResultItem } from '@/entities/friend';
 import { useFriendManager } from '../model/useFriendManager';
+import FriendAvatar from './FriendAvatar';
+
+const SEARCH_ACTION_LABEL: Record<RelationshipStatus, string> = {
+  NONE: '친구 추가',
+  PENDING_SENT: '신청됨',
+  PENDING_RECEIVED: '받은 신청 있음',
+  ACCEPTED: '이미 친구',
+  REJECTED: '재신청 불가',
+};
 
 const FriendManagerSection = () => {
   const {
     friends,
-    requests,
+    receivedRequests,
+    sentRequests,
     isLoading,
     isError,
-    target,
+    keyword,
+    handleKeywordChange,
+    searchResults,
+    isSearching,
     feedback,
     feedbackTone,
-    isCreating,
-    handleTargetChange,
-    handleSubmitRequest,
+    isCreatingRequestId,
+    handleSendRequest,
     handleAccept,
     handleReject,
     handleCancel,
     handleDeleteFriend,
   } = useFriendManager();
 
-  const incomingRequests = requests.filter((item) => item.direction === 'INCOMING');
-  const outgoingRequests = requests.filter((item) => item.direction === 'OUTGOING');
+  const renderSearchResult = (result: UserSearchResultItem) => {
+    const isSendable = result.relationshipStatus === 'NONE';
+    const isSendingThis = isCreatingRequestId === result.id;
+
+    return (
+      <div
+        key={result.id}
+        className="flex items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-white p-3"
+      >
+        <div className="flex min-w-0 items-center gap-3">
+          <FriendAvatar
+            nickname={result.nickname}
+            profileImageUrl={result.profileImageUrl}
+            size="sm"
+          />
+          <div className="min-w-0">
+            <p className="truncate font-semibold text-slate-900">{result.nickname}</p>
+            <p className="truncate text-sm text-slate-500">
+              {result.schoolInfo || '학교 정보 없음'}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => handleSendRequest(result.id)}
+          disabled={!isSendable || isSendingThis}
+          className={`h-10 shrink-0 rounded-2xl px-4 text-sm font-semibold transition ${
+            isSendable
+              ? 'bg-slate-900 text-white hover:bg-slate-800 disabled:opacity-70'
+              : 'border border-slate-200 text-slate-400'
+          }`}
+        >
+          {isSendingThis ? '전송 중...' : SEARCH_ACTION_LABEL[result.relationshipStatus]}
+        </button>
+      </div>
+    );
+  };
 
   return (
     <section className="rounded-[28px] bg-white p-6 shadow-sm sm:p-8">
@@ -28,7 +76,7 @@ const FriendManagerSection = () => {
         <div>
           <p className="text-sm font-semibold text-indigo-500">친구 관리</p>
           <p className="mt-2 text-sm text-slate-500">
-            친구 조회, 신청, 수락/거절, 신청 취소, 삭제까지 한 화면에서 처리할 수 있어요.
+            닉네임 또는 이메일로 검색해서 친구를 추가하고, 신청을 관리할 수 있어요.
           </p>
         </div>
         <div className="inline-flex items-center gap-2 rounded-2xl bg-slate-50 px-4 py-3 text-sm text-slate-600">
@@ -38,29 +86,19 @@ const FriendManagerSection = () => {
       </div>
 
       <div className="mt-6 rounded-[24px] border border-slate-100 bg-slate-50/70 p-5">
-        <div className="grid gap-4 md:grid-cols-[1fr_auto]">
-          <label className="block">
-            <span className="mb-2 block text-sm font-semibold text-slate-700">
-              친구 신청 대상
-            </span>
+        <label className="block">
+          <span className="mb-2 block text-sm font-semibold text-slate-700">친구 검색</span>
+          <div className="relative">
+            <Search className="pointer-events-none absolute top-1/2 left-4 h-4 w-4 -translate-y-1/2 text-slate-400" />
             <input
               type="text"
-              value={target}
-              onChange={(event) => handleTargetChange(event.target.value)}
-              placeholder="닉네임 또는 이메일"
-              className="h-12 w-full rounded-2xl border border-slate-200 bg-white px-4 text-sm outline-none transition focus:border-indigo-300"
+              value={keyword}
+              onChange={(event) => handleKeywordChange(event.target.value)}
+              placeholder="닉네임 또는 이메일을 입력하세요"
+              className="h-12 w-full rounded-2xl border border-slate-200 bg-white pr-4 pl-11 text-sm outline-none transition focus:border-indigo-300"
             />
-          </label>
-          <button
-            type="button"
-            onClick={handleSubmitRequest}
-            disabled={isCreating}
-            className="mt-7 inline-flex h-12 items-center justify-center gap-2 rounded-2xl bg-slate-900 px-5 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:opacity-70"
-          >
-            <MailPlus className="h-4 w-4" />
-            {isCreating ? '전송 중...' : '친구 신청'}
-          </button>
-        </div>
+          </div>
+        </label>
 
         {feedback ? (
           <p
@@ -71,10 +109,26 @@ const FriendManagerSection = () => {
             {feedback}
           </p>
         ) : null}
+
+        {keyword.trim() ? (
+          <div className="mt-4 space-y-2">
+            {isSearching ? (
+              <p className="text-sm text-slate-500">검색 중...</p>
+            ) : searchResults.length ? (
+              searchResults.map(renderSearchResult)
+            ) : (
+              <p className="text-sm text-slate-500">검색 결과가 없어요.</p>
+            )}
+          </div>
+        ) : null}
       </div>
 
-      {isLoading ? <p className="mt-6 text-sm text-slate-500">친구 정보를 불러오는 중입니다.</p> : null}
-      {isError ? <p className="mt-6 text-sm text-red-500">친구 정보를 불러오지 못했습니다.</p> : null}
+      {isLoading ? (
+        <p className="mt-6 text-sm text-slate-500">친구 정보를 불러오는 중입니다.</p>
+      ) : null}
+      {isError ? (
+        <p className="mt-6 text-sm text-red-500">친구 정보를 불러오지 못했습니다.</p>
+      ) : null}
 
       <div className="mt-8 grid gap-6">
         <div className="rounded-[24px] border border-slate-100 p-5">
@@ -83,23 +137,29 @@ const FriendManagerSection = () => {
             {friends.length ? (
               friends.map((friend) => (
                 <div
-                  key={friend.id}
+                  key={friend.friendshipId}
                   className="rounded-2xl border border-slate-100 bg-slate-50 p-4"
                 >
                   <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <p className="font-semibold text-slate-900">{friend.nickname}</p>
-                      <p className="mt-1 text-sm text-slate-500">
-                        {friend.mbti || 'MBTI 미설정'}
-                      </p>
-                      <p className="mt-2 text-sm text-slate-600">
-                        {friend.introduce || '한 줄 소개가 아직 없어요.'}
-                      </p>
+                    <div className="flex min-w-0 items-start gap-3">
+                      <FriendAvatar
+                        nickname={friend.user.nickname}
+                        profileImageUrl={friend.user.profileImageUrl}
+                      />
+                      <div className="min-w-0">
+                        <p className="font-semibold text-slate-900">{friend.user.nickname}</p>
+                        <p className="mt-1 text-sm text-slate-500">
+                          {friend.user.mbti || 'MBTI 미설정'}
+                        </p>
+                        <p className="mt-2 text-sm text-slate-600">
+                          {friend.user.introduce || '한 줄 소개가 아직 없어요.'}
+                        </p>
+                      </div>
                     </div>
                     <button
                       type="button"
-                      onClick={() => handleDeleteFriend(friend.id)}
-                      className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-red-200 px-3 text-sm font-semibold text-red-600 transition hover:bg-red-50"
+                      onClick={() => handleDeleteFriend(friend.friendshipId)}
+                      className="inline-flex h-10 shrink-0 items-center justify-center gap-2 rounded-2xl border border-red-200 px-3 text-sm font-semibold text-red-600 transition hover:bg-red-50"
                     >
                       <UserMinus className="h-4 w-4" />
                       삭제
@@ -116,25 +176,34 @@ const FriendManagerSection = () => {
         <div className="rounded-[24px] border border-slate-100 p-5">
           <h3 className="text-base font-bold text-slate-900 sm:text-lg">받은 신청</h3>
           <div className="mt-4 space-y-3">
-            {incomingRequests.length ? (
-              incomingRequests.map((request) => (
+            {receivedRequests.length ? (
+              receivedRequests.map((request) => (
                 <div
-                  key={request.id}
+                  key={request.friendshipId}
                   className="rounded-2xl border border-slate-100 bg-slate-50 p-4"
                 >
                   <div className="flex items-center justify-between gap-4">
-                    <p className="font-semibold text-slate-900">{request.senderNickname}</p>
+                    <div className="flex min-w-0 items-center gap-3">
+                      <FriendAvatar
+                        nickname={request.user.nickname}
+                        profileImageUrl={request.user.profileImageUrl}
+                        size="sm"
+                      />
+                      <p className="truncate font-semibold text-slate-900">
+                        {request.user.nickname}
+                      </p>
+                    </div>
                     <div className="flex shrink-0 gap-2">
                       <button
                         type="button"
-                        onClick={() => handleAccept(request.id)}
+                        onClick={() => handleAccept(request.friendshipId)}
                         className="h-10 rounded-2xl bg-slate-900 px-4 text-sm font-semibold text-white"
                       >
                         수락
                       </button>
                       <button
                         type="button"
-                        onClick={() => handleReject(request.id)}
+                        onClick={() => handleReject(request.friendshipId)}
                         className="h-10 rounded-2xl border border-slate-200 px-4 text-sm font-semibold text-slate-700"
                       >
                         거절
@@ -152,17 +221,26 @@ const FriendManagerSection = () => {
         <div className="rounded-[24px] border border-slate-100 p-5">
           <h3 className="text-base font-bold text-slate-900 sm:text-lg">보낸 신청</h3>
           <div className="mt-4 space-y-3">
-            {outgoingRequests.length ? (
-              outgoingRequests.map((request) => (
+            {sentRequests.length ? (
+              sentRequests.map((request) => (
                 <div
-                  key={request.id}
+                  key={request.friendshipId}
                   className="rounded-2xl border border-slate-100 bg-slate-50 p-4"
                 >
                   <div className="flex items-center justify-between gap-4">
-                    <p className="font-semibold text-slate-900">{request.receiverNickname}</p>
+                    <div className="flex min-w-0 items-center gap-3">
+                      <FriendAvatar
+                        nickname={request.user.nickname}
+                        profileImageUrl={request.user.profileImageUrl}
+                        size="sm"
+                      />
+                      <p className="truncate font-semibold text-slate-900">
+                        {request.user.nickname}
+                      </p>
+                    </div>
                     <button
                       type="button"
-                      onClick={() => handleCancel(request.id)}
+                      onClick={() => handleCancel(request.friendshipId)}
                       className="h-10 shrink-0 rounded-2xl border border-slate-200 px-4 text-sm font-semibold text-slate-700"
                     >
                       신청 취소

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -12,7 +12,14 @@ import type {
   PostListItemResponse,
 } from '@/entities/post/model/types';
 import type { DeleteMyUserResponse, GetMyUserResponse, UpdateMyUserRequest } from '@/entities/user';
-import type { GetFriendRequestsResponse, GetFriendsResponse } from '@/entities/friend';
+import type {
+  FriendRequestItem,
+  FriendSummary,
+  GetFriendRequestsResponse,
+  GetFriendsResponse,
+  RelationshipStatus,
+  SearchUsersResponse,
+} from '@/entities/friend';
 import type { MainLunchMenu } from '@/entities/lunch-menu';
 
 const currentUserId = 1;
@@ -362,29 +369,50 @@ const memberMetaByUserId: Record<
   },
 };
 
-let friendIds = [2];
-let friendRequests = [
+interface MockFriendship {
+  friendshipId: number;
+  requesterId: number;
+  receiverId: number;
+  status: 'PENDING' | 'ACCEPTED' | 'REJECTED';
+  createdAt: string;
+}
+
+let friendships: MockFriendship[] = [
   {
-    id: 1,
-    fromUserId: 3,
-    toUserId: 1,
-    senderNickname: '도서관러',
-    receiverNickname: '점심대장',
+    friendshipId: 1,
+    requesterId: 3,
+    receiverId: 1,
+    status: 'PENDING',
     createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-    direction: 'INCOMING' as const,
-    status: 'PENDING' as const,
   },
   {
-    id: 2,
-    fromUserId: 1,
-    toUserId: 4,
-    senderNickname: '점심대장',
-    receiverNickname: '제육파',
+    friendshipId: 2,
+    requesterId: 1,
+    receiverId: 4,
+    status: 'PENDING',
     createdAt: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
-    direction: 'OUTGOING' as const,
-    status: 'PENDING' as const,
+  },
+  {
+    friendshipId: 3,
+    requesterId: 1,
+    receiverId: 2,
+    status: 'ACCEPTED',
+    createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
   },
 ];
+let friendshipIdCounter = 4;
+
+const toPublicUser = (user: GetMyUserResponse) => ({
+  id: user.id,
+  nickname: user.nickname,
+  birthDate: user.birthDate,
+  gender: user.gender,
+  schoolInfo: user.schoolInfo,
+  introduce: user.introduce,
+  mbti: user.mbti,
+  createdAt: user.createdAt,
+  profileImageUrl: user.profileImageUrl,
+});
 
 let rooms: RoomDetailResponse[] = [
   {
@@ -859,8 +887,7 @@ export const handlers = [
     }
 
     isAccountDeleted = true;
-    friendIds = [];
-    friendRequests = [];
+    friendships = [];
 
     return HttpResponse.json<DeleteMyUserResponse>({
       message: '회원탈퇴가 완료되었습니다.',
@@ -885,22 +912,77 @@ export const handlers = [
     return HttpResponse.json({ imageURL });
   }),
 
+  http.get('/api/v1/users/search', async ({ request }) => {
+    await wait();
+    if (!isAuthorized(request)) {
+      return unauthorizedResponse();
+    }
+
+    const url = new URL(request.url);
+    const keyword = (url.searchParams.get('keyword') ?? '').trim().toLowerCase();
+
+    const items = mockUsers
+      .filter((user) => user.id !== currentUserId)
+      .filter(
+        (user) =>
+          Boolean(keyword) &&
+          (user.nickname.toLowerCase().includes(keyword) || user.email.toLowerCase() === keyword),
+      )
+      .slice(0, 20)
+      .map((user) => {
+        const friendship = friendships.find(
+          (item) =>
+            (item.requesterId === currentUserId && item.receiverId === user.id) ||
+            (item.receiverId === currentUserId && item.requesterId === user.id),
+        );
+
+        let relationshipStatus: RelationshipStatus = 'NONE';
+        if (friendship?.status === 'ACCEPTED') {
+          relationshipStatus = 'ACCEPTED';
+        } else if (friendship?.status === 'REJECTED') {
+          relationshipStatus = 'REJECTED';
+        } else if (friendship?.status === 'PENDING') {
+          relationshipStatus =
+            friendship.requesterId === currentUserId ? 'PENDING_SENT' : 'PENDING_RECEIVED';
+        }
+
+        return {
+          id: user.id,
+          nickname: user.nickname,
+          profileImageUrl: user.profileImageUrl,
+          schoolInfo: user.schoolInfo,
+          relationshipStatus,
+        };
+      });
+
+    return HttpResponse.json<SearchUsersResponse>({ items });
+  }),
+
   http.get('/api/v1/friends', async ({ request }) => {
     await wait();
     if (!isAuthorized(request)) {
       return unauthorizedResponse();
     }
 
-    const items = friendIds
-      .map((friendId) => findUserById(friendId))
-      .filter((friend): friend is GetMyUserResponse => Boolean(friend))
-      .map((friend) => ({
-        id: friend.id,
-        nickname: friend.nickname,
-        mbti: friend.mbti ?? '미설정',
-        introduce: friend.introduce ?? '',
-        profileImageUrl: friend.profileImageUrl ?? '',
-      }));
+    const items = friendships
+      .filter(
+        (item) =>
+          item.status === 'ACCEPTED' &&
+          (item.requesterId === currentUserId || item.receiverId === currentUserId),
+      )
+      .map((item) => {
+        const otherUserId = item.requesterId === currentUserId ? item.receiverId : item.requesterId;
+        const otherUser = findUserById(otherUserId);
+
+        return otherUser
+          ? {
+              friendshipId: item.friendshipId,
+              status: 'ACCEPTED' as const,
+              user: toPublicUser(otherUser),
+            }
+          : null;
+      })
+      .filter((item): item is FriendSummary => Boolean(item));
 
     return HttpResponse.json<GetFriendsResponse>({ items });
   }),
@@ -911,9 +993,32 @@ export const handlers = [
       return unauthorizedResponse();
     }
 
-    return HttpResponse.json<GetFriendRequestsResponse>({
-      items: friendRequests,
-    });
+    const items = friendships
+      .filter(
+        (item) =>
+          item.status === 'PENDING' &&
+          (item.requesterId === currentUserId || item.receiverId === currentUserId),
+      )
+      .map((item) => {
+        const direction: 'SENT' | 'RECEIVED' =
+          item.requesterId === currentUserId ? 'SENT' : 'RECEIVED';
+        const otherUserId = direction === 'SENT' ? item.receiverId : item.requesterId;
+        const otherUser = findUserById(otherUserId);
+
+        return otherUser
+          ? {
+              friendshipId: item.friendshipId,
+              requesterId: item.requesterId,
+              receiverId: item.receiverId,
+              direction,
+              user: toPublicUser(otherUser),
+              createdAt: item.createdAt,
+            }
+          : null;
+      })
+      .filter((item): item is FriendRequestItem => Boolean(item));
+
+    return HttpResponse.json<GetFriendRequestsResponse>({ items });
   }),
 
   http.post('/api/v1/friends/requests', async ({ request }) => {
@@ -922,79 +1027,109 @@ export const handlers = [
       return unauthorizedResponse();
     }
 
-    const payload = (await request.json()) as { target?: string };
-    const target = payload.target?.trim().toLowerCase();
-    const targetUser = mockUsers.find(
-      (user) =>
-        user.id !== currentUserId &&
-        (user.nickname.toLowerCase() === target || user.email.toLowerCase() === target),
-    );
+    const payload = (await request.json()) as { receiverId?: number };
+    const targetUser = payload.receiverId ? findUserById(payload.receiverId) : undefined;
 
-    if (!targetUser) {
+    if (!payload.receiverId || !targetUser) {
       return HttpResponse.json({ message: '대상 사용자를 찾을 수 없어요.' }, { status: 404 });
     }
 
-    const duplicated = friendRequests.some((item) => item.toUserId === targetUser.id);
-    if (duplicated || friendIds.includes(targetUser.id)) {
+    const duplicated = friendships.some(
+      (item) =>
+        (item.requesterId === currentUserId && item.receiverId === payload.receiverId) ||
+        (item.receiverId === currentUserId && item.requesterId === payload.receiverId),
+    );
+
+    if (duplicated) {
       return HttpResponse.json({ message: '이미 친구 또는 신청된 사용자예요.' }, { status: 409 });
     }
 
-    const nextRequest = {
-      id: Math.max(0, ...friendRequests.map((item) => item.id)) + 1,
-      fromUserId: currentUserId,
-      toUserId: targetUser.id,
-      senderNickname: currentUser.nickname,
-      receiverNickname: targetUser.nickname,
+    const nextFriendship: MockFriendship = {
+      friendshipId: friendshipIdCounter++,
+      requesterId: currentUserId,
+      receiverId: payload.receiverId,
+      status: 'PENDING',
       createdAt: new Date().toISOString(),
-      direction: 'OUTGOING' as const,
-      status: 'PENDING' as const,
     };
 
-    friendRequests = [nextRequest, ...friendRequests];
-    return HttpResponse.json(nextRequest, { status: 201 });
+    friendships = [nextFriendship, ...friendships];
+
+    return HttpResponse.json(
+      {
+        id: nextFriendship.friendshipId,
+        requesterId: nextFriendship.requesterId,
+        receiverId: nextFriendship.receiverId,
+        status: nextFriendship.status,
+        createdAt: nextFriendship.createdAt,
+      },
+      { status: 201 },
+    );
   }),
 
-  http.patch('/api/v1/friends/requests/:requestId', async ({ params, request }) => {
+  http.patch('/api/v1/friends/requests/:friendshipId/accept', async ({ params, request }) => {
     await wait();
     if (!isAuthorized(request)) {
       return unauthorizedResponse();
     }
 
-    const requestId = Number(params.requestId);
-    const payload = (await request.json()) as { accepted?: boolean };
-    const targetRequest = friendRequests.find((item) => item.id === requestId);
+    const target = friendships.find((item) => item.friendshipId === Number(params.friendshipId));
 
-    if (!targetRequest) {
+    if (!target) {
       return HttpResponse.json({ message: '친구 신청을 찾을 수 없어요.' }, { status: 404 });
     }
 
-    if (payload.accepted) {
-      friendIds = Array.from(new Set([...friendIds, targetRequest.fromUserId]));
-    }
+    target.status = 'ACCEPTED';
 
-    friendRequests = friendRequests.filter((item) => item.id !== requestId);
-
-    return new HttpResponse(null, { status: 204 });
+    return HttpResponse.json({
+      id: target.friendshipId,
+      requesterId: target.requesterId,
+      receiverId: target.receiverId,
+      status: target.status,
+      createdAt: target.createdAt,
+    });
   }),
 
-  http.delete('/api/v1/friends/requests/:requestId', async ({ params, request }) => {
+  http.patch('/api/v1/friends/requests/:friendshipId/reject', async ({ params, request }) => {
     await wait();
     if (!isAuthorized(request)) {
       return unauthorizedResponse();
     }
 
-    friendRequests = friendRequests.filter((item) => item.id !== Number(params.requestId));
+    const target = friendships.find((item) => item.friendshipId === Number(params.friendshipId));
 
-    return new HttpResponse(null, { status: 204 });
+    if (!target) {
+      return HttpResponse.json({ message: '친구 신청을 찾을 수 없어요.' }, { status: 404 });
+    }
+
+    target.status = 'REJECTED';
+
+    return HttpResponse.json({
+      id: target.friendshipId,
+      requesterId: target.requesterId,
+      receiverId: target.receiverId,
+      status: target.status,
+      createdAt: target.createdAt,
+    });
   }),
 
-  http.delete('/api/v1/friends/:friendId', async ({ params, request }) => {
+  http.delete('/api/v1/friends/requests/:friendshipId', async ({ params, request }) => {
     await wait();
     if (!isAuthorized(request)) {
       return unauthorizedResponse();
     }
 
-    friendIds = friendIds.filter((friendId) => friendId !== Number(params.friendId));
+    friendships = friendships.filter((item) => item.friendshipId !== Number(params.friendshipId));
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.delete('/api/v1/friends/:friendshipId', async ({ params, request }) => {
+    await wait();
+    if (!isAuthorized(request)) {
+      return unauthorizedResponse();
+    }
+
+    friendships = friendships.filter((item) => item.friendshipId !== Number(params.friendshipId));
 
     return new HttpResponse(null, { status: 204 });
   }),


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 친구 목록/검색/신청/수락/거절/취소/삭제 기능을 백엔드 API와 연동

## ✨ 변경 사항 (Changes)

- 유저 검색(`GET /users/search`) 연동 — 닉네임/이메일로 검색해서 친구 신청 대상(`receiverId`)을 찾는 기능 구현
- 검색 결과에 `relationshipStatus`(NONE/PENDING_SENT/PENDING_RECEIVED/ACCEPTED/REJECTED)를 반영해 버튼 상태를 분기
- 친구 신청 요청 body를 `target`(닉네임/이메일 문자열) → `receiverId`(숫자)로 변경
- 수락/거절을 단일 엔드포인트에서 `PATCH .../accept`, `PATCH .../reject` 별도 엔드포인트 호출로 분리
- 대기중 친구 신청 목록(`GET /friends/requests`) 연동, 응답의 `direction` 필드로 받은/보낸 신청 구분
- `entities/user`에 공개 프로필 공용 타입 `PublicUser` 추가
- MSW 목업을 새 API 구조(`friendships` 단일 목록, 유저 검색 목업 포함)에 맞게 정리

## 📸 스크린샷 (Screenshots)

- 스크린샷 첨부

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 참고 사항 기재

## 🧐 이슈 (Related Issues)

- Closes #164 
