### PR TITLE
refactor: (#167) 방 API 정합성 수정 및 UX 개선

### DIFF
--- a/src/entities/room/api/roomList.ts
+++ b/src/entities/room/api/roomList.ts
@@ -9,7 +9,7 @@ export async function getRooms(params: GetRoomsParams = {}): Promise<GetRoomsRes
       minAge: params.minAge,
       maxAge: params.maxAge,
       cursor: params.cursor,
-      size: params.size,
+      limit: params.limit,
     },
   });
 

--- a/src/entities/room/api/roomListQueries.ts
+++ b/src/entities/room/api/roomListQueries.ts
@@ -9,15 +9,15 @@ export const roomListQueryOptions = (filters: RoomListFilters = {}) =>
     queryFn: () => getRooms(filters),
   });
 
-export const roomInfiniteListQueryOptions = (filters: RoomListFilters = {}, size = 10) =>
+export const roomInfiniteListQueryOptions = (filters: RoomListFilters = {}, limit = 10) =>
   infiniteQueryOptions({
-    queryKey: roomQueryKeys.infiniteList(filters, size),
+    queryKey: roomQueryKeys.infiniteList(filters, limit),
     initialPageParam: undefined as string | undefined,
     queryFn: ({ pageParam }) =>
       getRooms({
         ...filters,
         cursor: pageParam,
-        size,
+        limit,
       }),
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined),
   });

--- a/src/entities/room/api/roomQueryKeys.ts
+++ b/src/entities/room/api/roomQueryKeys.ts
@@ -4,8 +4,8 @@ export const roomQueryKeys = {
   all: () => ['rooms'] as const,
   lists: () => [...roomQueryKeys.all(), 'list'] as const,
   list: (filters: RoomListFilters = {}) => [...roomQueryKeys.lists(), filters] as const,
-  infiniteList: (filters: RoomListFilters = {}, size = 10) =>
-    [...roomQueryKeys.lists(), 'infinite', filters, size] as const,
+  infiniteList: (filters: RoomListFilters = {}, limit = 10) =>
+    [...roomQueryKeys.lists(), 'infinite', filters, limit] as const,
   details: () => [...roomQueryKeys.all(), 'detail'] as const,
   detail: (roomId: number) => [...roomQueryKeys.details(), roomId] as const,
   membersAll: () => [...roomQueryKeys.all(), 'members'] as const,

--- a/src/entities/room/index.ts
+++ b/src/entities/room/index.ts
@@ -9,6 +9,7 @@ export type {
   RoomListFilters,
   RoomListItemResponse,
   RoomMemberResponse,
+  RoomSyncRequest,
   UpdateRoomRequest,
 } from './model/types';
 export { getRoomDetail } from './api/roomDetail';

--- a/src/entities/room/model/roomCache.ts
+++ b/src/entities/room/model/roomCache.ts
@@ -5,4 +5,5 @@ export const invalidateRoomCaches = (queryClient: QueryClient, roomId: number) =
   Promise.all([
     queryClient.invalidateQueries({ queryKey: roomQueryKeys.lists() }),
     queryClient.invalidateQueries({ queryKey: roomQueryKeys.detail(roomId) }),
+    queryClient.invalidateQueries({ queryKey: roomQueryKeys.members(roomId) }),
   ]);

--- a/src/entities/room/model/roomMappers.ts
+++ b/src/entities/room/model/roomMappers.ts
@@ -1,7 +1,9 @@
 import type { RoomDetailResponse, RoomListFilters, RoomListItemResponse } from './types';
 import type { MainRoom } from './mainRoom';
 
-export const toMainRoomType = (roomType: RoomListItemResponse['roomType']): MainRoom['roomType'] => {
+export const toMainRoomType = (
+  roomType: RoomListItemResponse['roomType'],
+): MainRoom['roomType'] => {
   if (roomType === 'MALE' || roomType === 'FEMALE') {
     return roomType;
   }
@@ -25,13 +27,15 @@ export const toMainRoom = (room: RoomListItemResponse): MainRoom => ({
   roomType: toMainRoomType(room.roomType),
   minAge: room.minAge,
   maxAge: room.maxAge,
-  currentCount: room.currentCount,
+  currentCount: room.currentMembersCount,
   capacity: room.maxMembersCount,
   place: room.place,
   lunchAt: formatLunchAt(room.lunchAt),
 });
 
-export const toDetailRoomType = (roomType: RoomDetailResponse['roomType']): MainRoom['roomType'] => {
+export const toDetailRoomType = (
+  roomType: RoomDetailResponse['roomType'],
+): MainRoom['roomType'] => {
   if (roomType === 'MALE' || roomType === 'FEMALE') {
     return roomType;
   }

--- a/src/entities/room/model/types.ts
+++ b/src/entities/room/model/types.ts
@@ -1,3 +1,5 @@
+import type { Gender } from '@/entities/user';
+
 export interface RoomListItemResponse {
   id: number;
   title: string;
@@ -7,12 +9,13 @@ export interface RoomListItemResponse {
   maxAge: number;
   place: string;
   lunchAt: string;
-  currentCount: number;
+  currentMembersCount: number;
 }
 
 export interface GetRoomsResponse {
   items: RoomListItemResponse[];
   nextCursor?: string | null;
+  hasNext: boolean;
 }
 
 export interface RoomListFilters {
@@ -24,7 +27,7 @@ export interface RoomListFilters {
 
 export interface GetRoomsParams extends RoomListFilters {
   cursor?: string;
-  size?: number;
+  limit?: number;
 }
 
 export interface RoomDetailResponse {
@@ -71,11 +74,12 @@ export interface RoomJoinResponse {
 }
 
 export interface RoomMemberResponse {
-  userId: number;
+  id: number;
   nickname: string;
   mbti: string;
   profileImageUrl: string;
-  schoolName: string;
+  schoolInfo: string;
+  gender: Gender;
   age: number;
 }
 
@@ -86,4 +90,8 @@ export interface GetRoomMembersResponse {
 export interface KickRoomMemberRequest {
   roomId: number;
   userId: number;
+}
+
+export interface RoomSyncRequest {
+  roomId: number;
 }

--- a/src/features/room/editor/model/roomEditor.types.ts
+++ b/src/features/room/editor/model/roomEditor.types.ts
@@ -17,7 +17,7 @@ export interface RoomEditorModalProps {
   mode?: 'create' | 'edit';
   roomId?: number;
   initialValues?: RoomEditorFormValues;
-  onSuccess?: () => void;
+  onSuccess?: (room: RoomDetailResponse) => void;
   onError?: (message: string) => void;
   onRequireLogin?: () => void;
 }

--- a/src/features/room/editor/model/useCreateRoomSubmit.ts
+++ b/src/features/room/editor/model/useCreateRoomSubmit.ts
@@ -24,12 +24,12 @@ export const useCreateRoomSubmit = ({
 
   const createRoomMutation = useMutation({
     mutationFn: createRoom,
-    onSuccess: async () => {
+    onSuccess: async (room) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: roomQueryKeys.lists() }),
         queryClient.invalidateQueries({ queryKey: roomQueryKeys.details() }),
       ]);
-      onSuccess?.();
+      onSuccess?.(room);
     },
   });
 

--- a/src/features/room/editor/model/useUpdateRoomSubmit.ts
+++ b/src/features/room/editor/model/useUpdateRoomSubmit.ts
@@ -30,13 +30,13 @@ export const useUpdateRoomSubmit = ({
       targetRoomId: number;
       payload: Parameters<typeof updateRoom>[1];
     }) => updateRoom(targetRoomId, payload),
-    onSuccess: async (_, variables) => {
+    onSuccess: async (room, variables) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: roomQueryKeys.lists() }),
         queryClient.invalidateQueries({ queryKey: roomQueryKeys.detail(variables.targetRoomId) }),
         queryClient.invalidateQueries({ queryKey: roomQueryKeys.members(variables.targetRoomId) }),
       ]);
-      onSuccess?.();
+      onSuccess?.(room);
     },
   });
 

--- a/src/features/room/leave/api.ts
+++ b/src/features/room/leave/api.ts
@@ -1,5 +1,5 @@
 import client from '@/shared/api/client';
 
 export async function leaveRoom(roomId: number): Promise<void> {
-  await client.post(`/api/v1/rooms/${roomId}/leave`);
+  await client.delete(`/api/v1/rooms/${roomId}/leave`);
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -299,7 +299,8 @@ const memberMetaByUserId: Record<
     nickname: string;
     mbti: string;
     profileImageUrl: string;
-    schoolName: string;
+    schoolInfo: string;
+    gender: 'MALE' | 'FEMALE';
     age: number;
   }
 > = {
@@ -308,7 +309,8 @@ const memberMetaByUserId: Record<
     mbti: 'ENFP',
     profileImageUrl:
       'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=300&q=80',
-    schoolName: '한국대학교 컴퓨터공학과',
+    schoolInfo: '한국대학교 컴퓨터공학과',
+    gender: 'MALE',
     age: 25,
   },
   2: {
@@ -316,7 +318,8 @@ const memberMetaByUserId: Record<
     mbti: 'ISTJ',
     profileImageUrl:
       'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=300&q=80',
-    schoolName: '한국대학교 경영학과',
+    schoolInfo: '한국대학교 경영학과',
+    gender: 'MALE',
     age: 26,
   },
   3: {
@@ -324,7 +327,8 @@ const memberMetaByUserId: Record<
     mbti: 'INTP',
     profileImageUrl:
       'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=300&q=80',
-    schoolName: '한국대학교 국어국문학과',
+    schoolInfo: '한국대학교 국어국문학과',
+    gender: 'FEMALE',
     age: 24,
   },
   4: {
@@ -332,7 +336,8 @@ const memberMetaByUserId: Record<
     mbti: 'ESFP',
     profileImageUrl:
       'https://images.unsplash.com/photo-1488426862026-3ee34a7d66df?auto=format&fit=crop&w=300&q=80',
-    schoolName: '한국대학교 시각디자인학과',
+    schoolInfo: '한국대학교 시각디자인학과',
+    gender: 'FEMALE',
     age: 23,
   },
   5: {
@@ -340,7 +345,8 @@ const memberMetaByUserId: Record<
     mbti: 'ISFJ',
     profileImageUrl:
       'https://images.unsplash.com/photo-1546961329-78bef0414d7c?auto=format&fit=crop&w=300&q=80',
-    schoolName: '한국대학교 생명과학과',
+    schoolInfo: '한국대학교 생명과학과',
+    gender: 'FEMALE',
     age: 20,
   },
   6: {
@@ -348,7 +354,8 @@ const memberMetaByUserId: Record<
     mbti: 'ENTJ',
     profileImageUrl:
       'https://images.unsplash.com/photo-1504593811423-6dd665756598?auto=format&fit=crop&w=300&q=80',
-    schoolName: '한국대학교 화학과',
+    schoolInfo: '한국대학교 화학과',
+    gender: 'MALE',
     age: 22,
   },
   7: {
@@ -356,7 +363,8 @@ const memberMetaByUserId: Record<
     mbti: 'ISTP',
     profileImageUrl:
       'https://images.unsplash.com/photo-1502767089025-6572583495b0?auto=format&fit=crop&w=300&q=80',
-    schoolName: '한국대학교 기계공학과',
+    schoolInfo: '한국대학교 기계공학과',
+    gender: 'MALE',
     age: 27,
   },
   8: {
@@ -364,7 +372,8 @@ const memberMetaByUserId: Record<
     mbti: 'ESTP',
     profileImageUrl:
       'https://images.unsplash.com/photo-1504257432389-52343af06ae3?auto=format&fit=crop&w=300&q=80',
-    schoolName: '한국대학교 전자공학과',
+    schoolInfo: '한국대학교 전자공학과',
+    gender: 'MALE',
     age: 28,
   },
 };
@@ -789,11 +798,12 @@ function toRoomMember(userId: number): GetRoomMembersResponse['items'][number] {
   const memberMeta = memberMetaByUserId[userId];
 
   return {
-    userId,
+    id: userId,
     nickname: memberMeta?.nickname ?? `사용자${userId}`,
     mbti: memberMeta?.mbti ?? '미설정',
     profileImageUrl: memberMeta?.profileImageUrl ?? '',
-    schoolName: memberMeta?.schoolName ?? '학교 정보 미등록',
+    schoolInfo: memberMeta?.schoolInfo ?? '학교 정보 미등록',
+    gender: memberMeta?.gender ?? 'MALE',
     age: memberMeta?.age ?? 0,
   };
 }
@@ -821,7 +831,7 @@ const toRoomListItem = (room: RoomDetailResponse): RoomListItemResponse => ({
   maxAge: room.maxAge,
   place: room.place,
   lunchAt: room.lunchAt,
-  currentCount: room.currentMembersCount,
+  currentMembersCount: room.currentMembersCount,
 });
 
 const getRoom = (roomId: number) => rooms.find((room) => room.id === roomId);
@@ -1141,7 +1151,7 @@ export const handlers = [
     const status = url.searchParams.get('status');
     const minAge = Number(url.searchParams.get('minAge') ?? NaN);
     const maxAge = Number(url.searchParams.get('maxAge') ?? NaN);
-    const size = Number(url.searchParams.get('size') ?? 10);
+    const limit = Number(url.searchParams.get('limit') ?? 10);
     const cursor = Number(url.searchParams.get('cursor') ?? 0);
 
     const filteredRooms = rooms.filter((room) => {
@@ -1151,12 +1161,14 @@ export const handlers = [
       if (Number.isFinite(maxAge) && room.minAge > maxAge) return false;
       return true;
     });
-    const pageItems = filteredRooms.slice(cursor, cursor + size);
-    const nextCursor = cursor + size < filteredRooms.length ? String(cursor + size) : null;
+    const pageItems = filteredRooms.slice(cursor, cursor + limit);
+    const hasNext = cursor + limit < filteredRooms.length;
+    const nextCursor = hasNext ? String(cursor + limit) : null;
 
     return HttpResponse.json<GetRoomsResponse>({
       items: pageItems.map(toRoomListItem),
       nextCursor,
+      hasNext,
     });
   }),
 
@@ -1192,6 +1204,33 @@ export const handlers = [
     });
   }),
 
+  http.delete('/api/v1/rooms/:roomId/members/:userId', async ({ params, request }) => {
+    await wait();
+    if (!isAuthorized(request)) {
+      return unauthorizedResponse();
+    }
+
+    const roomId = Number(params.roomId);
+    const userId = Number(params.userId);
+    const room = getRoom(roomId);
+
+    if (!room) {
+      return HttpResponse.json({ message: '방을 찾을 수 없어요.' }, { status: 404 });
+    }
+
+    if (room.hostUserId !== currentUserId) {
+      return forbiddenResponse();
+    }
+
+    membersByRoomId[roomId] = (membersByRoomId[roomId] ?? []).filter(
+      (member) => member.id !== userId,
+    );
+    room.currentMembersCount = Math.max(1, room.currentMembersCount - 1);
+    room.status = 'OPEN';
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
   http.post('/api/v1/rooms/:roomId/join', async ({ params }) => {
     await wait();
     const roomId = Number(params.roomId);
@@ -1202,14 +1241,17 @@ export const handlers = [
     room.currentMembersCount = Math.min(room.maxMembersCount, room.currentMembersCount + 1);
     room.status = room.currentMembersCount >= room.maxMembersCount ? 'FULL' : 'OPEN';
 
-    return HttpResponse.json({
-      roomId,
-      userId: currentUserId,
-      createdAt: new Date().toISOString(),
-    });
+    return HttpResponse.json(
+      {
+        roomId,
+        userId: currentUserId,
+        createdAt: new Date().toISOString(),
+      },
+      { status: 201 },
+    );
   }),
 
-  http.post('/api/v1/rooms/:roomId/leave', async ({ params }) => {
+  http.delete('/api/v1/rooms/:roomId/leave', async ({ params }) => {
     await wait();
     const roomId = Number(params.roomId);
     const room = getRoom(roomId);
@@ -1218,7 +1260,7 @@ export const handlers = [
       room.status = 'OPEN';
     }
     membersByRoomId[roomId] = (membersByRoomId[roomId] ?? []).filter(
-      (member) => member.userId !== currentUserId,
+      (member) => member.id !== currentUserId,
     );
     return new HttpResponse(null, { status: 204 });
   }),

--- a/src/pages/main/model/useMainPage.ts
+++ b/src/pages/main/model/useMainPage.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { PostSyncRequest } from '@/entities/post';
+import type { RoomSyncRequest } from '@/entities/room';
 import type { MainTab } from '../ui/layout/main-tabs';
 
 export const useMainPage = () => {
@@ -8,6 +9,7 @@ export const useMainPage = () => {
   const [isCreateRoomModalOpen, setIsCreateRoomModalOpen] = useState(false);
   const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState(false);
   const [postSyncRequest, setPostSyncRequest] = useState<PostSyncRequest | null>(null);
+  const [roomSyncRequest, setRoomSyncRequest] = useState<RoomSyncRequest | null>(null);
 
   return {
     dialogs: {
@@ -25,6 +27,10 @@ export const useMainPage = () => {
     postSync: {
       postSyncRequest,
       setPostSyncRequest,
+    },
+    roomSync: {
+      roomSyncRequest,
+      setRoomSyncRequest,
     },
   };
 };

--- a/src/pages/main/ui/MainPage.tsx
+++ b/src/pages/main/ui/MainPage.tsx
@@ -6,7 +6,7 @@ import MainPageDialogs from './MainPageDialogs';
 import { useMainPage } from '../model/useMainPage';
 
 const MainPage = () => {
-  const { dialogs, tabs, postSync } = useMainPage();
+  const { dialogs, tabs, postSync, roomSync } = useMainPage();
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -21,6 +21,8 @@ const MainPage = () => {
           onCreatePostClick={() => dialogs.setIsCreatePostModalOpen(true)}
           postSyncRequest={postSync.postSyncRequest}
           onPostSyncHandled={() => postSync.setPostSyncRequest(null)}
+          roomSyncRequest={roomSync.roomSyncRequest}
+          onRoomSyncHandled={() => roomSync.setRoomSyncRequest(null)}
           onRequireLogin={() => dialogs.setIsLoginModalOpen(true)}
         />
       </main>
@@ -33,6 +35,7 @@ const MainPage = () => {
         isCreatePostModalOpen={dialogs.isCreatePostModalOpen}
         setIsCreatePostModalOpen={dialogs.setIsCreatePostModalOpen}
         setPostSyncRequest={postSync.setPostSyncRequest}
+        setRoomSyncRequest={roomSync.setRoomSyncRequest}
       />
     </div>
   );

--- a/src/pages/main/ui/MainPageDialogs.tsx
+++ b/src/pages/main/ui/MainPageDialogs.tsx
@@ -1,4 +1,5 @@
 import type { PostSyncRequest } from '@/entities/post';
+import type { RoomSyncRequest } from '@/entities/room';
 import PostEditorModal from '@/features/post/editor';
 import RoomEditorModal from '@/features/room/editor';
 import AuthDialog from '@/widgets/auth-dialog';
@@ -10,6 +11,7 @@ interface MainPageDialogsProps {
   isCreatePostModalOpen: boolean;
   setIsCreatePostModalOpen: (isOpen: boolean) => void;
   setPostSyncRequest: (value: PostSyncRequest | null) => void;
+  setRoomSyncRequest: (value: RoomSyncRequest | null) => void;
 }
 
 const MainPageDialogs = ({
@@ -20,6 +22,7 @@ const MainPageDialogs = ({
   isCreatePostModalOpen,
   setIsCreatePostModalOpen,
   setPostSyncRequest,
+  setRoomSyncRequest,
 }: MainPageDialogsProps) => (
   <>
     <AuthDialog isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
@@ -27,6 +30,10 @@ const MainPageDialogs = ({
       isOpen={isCreateRoomModalOpen}
       onClose={() => setIsCreateRoomModalOpen(false)}
       onRequireLogin={() => setIsLoginModalOpen(true)}
+      onSuccess={(room) => {
+        setIsCreateRoomModalOpen(false);
+        setRoomSyncRequest({ roomId: room.id });
+      }}
     />
     <PostEditorModal
       isOpen={isCreatePostModalOpen}

--- a/src/pages/main/ui/layout/main-tab-section/ui/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/main-tab-section/ui/MainTabSection.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import type { PostSyncRequest } from '@/entities/post';
+import type { RoomSyncRequest } from '@/entities/room';
 import { myUserQueryOptions } from '@/entities/user';
 import { lunchMenuListQueryOptions, lunchMenuQueryKeys, type MainLunchMenu } from '@/entities/lunch-menu';
 import type { MainTab } from '../../main-tabs/model/types';
@@ -17,6 +18,8 @@ interface MainTabSectionProps {
   onCreatePostClick: () => void;
   postSyncRequest: PostSyncRequest | null;
   onPostSyncHandled: () => void;
+  roomSyncRequest: RoomSyncRequest | null;
+  onRoomSyncHandled: () => void;
   onRequireLogin: () => void;
 }
 
@@ -40,6 +43,8 @@ const MainTabSection = ({
   onCreatePostClick,
   postSyncRequest,
   onPostSyncHandled,
+  roomSyncRequest,
+  onRoomSyncHandled,
   onRequireLogin,
 }: MainTabSectionProps) => {
   const queryClient = useQueryClient();
@@ -138,7 +143,13 @@ const MainTabSection = ({
         ) : null}
       </div>
 
-      {activeTab === 'ROOM' ? <RoomSection onRequireLogin={onRequireLogin} /> : null}
+      {activeTab === 'ROOM' ? (
+        <RoomSection
+          onRequireLogin={onRequireLogin}
+          roomSyncRequest={roomSyncRequest}
+          onRoomSyncHandled={onRoomSyncHandled}
+        />
+      ) : null}
       {activeTab === 'LUNCH' ? (
         <LunchSection
           lunchMenus={lunchMenus}

--- a/src/widgets/room-section/model/resolveInitialJoinedRoomId.ts
+++ b/src/widgets/room-section/model/resolveInitialJoinedRoomId.ts
@@ -1,7 +1,7 @@
 interface ResolveInitialJoinedRoomIdParams {
   selectedRoomId: number | null;
   currentUserId: number | null;
-  roomMembers: Array<{ userId: number }>;
+  roomMembers: Array<{ id: number }>;
 }
 
 export const resolveInitialJoinedRoomId = ({
@@ -13,7 +13,5 @@ export const resolveInitialJoinedRoomId = ({
     return null;
   }
 
-  return roomMembers.some((member) => member.userId === currentUserId)
-    ? selectedRoomId
-    : null;
+  return roomMembers.some((member) => member.id === currentUserId) ? selectedRoomId : null;
 };

--- a/src/widgets/room-section/model/useInfiniteRooms.ts
+++ b/src/widgets/room-section/model/useInfiniteRooms.ts
@@ -3,7 +3,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { roomInfiniteListQueryOptions, toMainRoom, toRoomListFilters } from '@/entities/room';
 import { INITIAL_ROOM_FILTER_STATE, type RoomFilterState } from './constants';
 
-const ROOM_LIST_DEFAULT_SIZE = 10;
+const ROOM_LIST_DEFAULT_LIMIT = 10;
 
 export const useInfiniteRooms = () => {
   const roomListLoadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -13,7 +13,7 @@ export const useInfiniteRooms = () => {
 
   const roomFilters = toRoomListFilters(roomFilterState);
   const roomsQuery = useInfiniteQuery(
-    roomInfiniteListQueryOptions(roomFilters, ROOM_LIST_DEFAULT_SIZE),
+    roomInfiniteListQueryOptions(roomFilters, ROOM_LIST_DEFAULT_LIMIT),
   );
 
   const rooms = useMemo(

--- a/src/widgets/room-section/model/useRoomSection.ts
+++ b/src/widgets/room-section/model/useRoomSection.ts
@@ -1,13 +1,19 @@
+import { useEffect } from 'react';
+import type { RoomSyncRequest } from '@/entities/room';
 import { useRoomSectionActions } from './useRoomSectionActions';
 import { useRoomSectionData } from './useRoomSectionData';
 import { useRoomSectionMeta } from './useRoomSectionMeta';
 
 interface UseRoomSectionParams {
   onRequireLogin: () => void;
+  roomSyncRequest: RoomSyncRequest | null;
+  onRoomSyncHandled: () => void;
 }
 
 export const useRoomSection = ({
   onRequireLogin,
+  roomSyncRequest,
+  onRoomSyncHandled,
 }: UseRoomSectionParams) => {
   const {
     infiniteRooms,
@@ -24,6 +30,17 @@ export const useRoomSection = ({
     onRequireLogin,
     setSelectedRoomId: roomSelectionState.setSelectedRoomId,
   });
+
+  useEffect(() => {
+    if (!roomSyncRequest) {
+      return;
+    }
+
+    roomSelectionState.setSelectedRoomId(roomSyncRequest.roomId);
+    roomActions.setJoinedRoomId(roomSyncRequest.roomId);
+    onRoomSyncHandled();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [roomSyncRequest, onRoomSyncHandled]);
   const { detailDisplay, meta } = useRoomSectionMeta({
     isRoomListLoading: infiniteRooms.roomsQuery.isLoading,
     isRoomListError: infiniteRooms.roomsQuery.isError,

--- a/src/widgets/room-section/model/useRoomSectionActions.ts
+++ b/src/widgets/room-section/model/useRoomSectionActions.ts
@@ -4,7 +4,7 @@ import { useRoomActions } from './useRoomActions';
 interface UseRoomSectionActionsParams {
   selectedRoomId: number | null;
   currentUserId: number | null;
-  roomMembers: { userId: number }[];
+  roomMembers: { id: number }[];
   isHostUser: boolean;
   onRequireLogin: () => void;
   setSelectedRoomId: (roomId: number | null) => void;

--- a/src/widgets/room-section/model/useRoomSelectionState.ts
+++ b/src/widgets/room-section/model/useRoomSelectionState.ts
@@ -9,13 +9,11 @@ export const useRoomSelectionState = ({ rooms }: UseRoomSelectionStateParams) =>
   const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
 
   const effectiveSelectedRoomId = useMemo(() => {
-    if (rooms.length === 0) {
+    if (selectedRoomId === null) {
       return null;
     }
 
-    const hasSelected = selectedRoomId !== null && rooms.some((room) => room.id === selectedRoomId);
-
-    return hasSelected ? selectedRoomId : rooms[0].id;
+    return rooms.some((room) => room.id === selectedRoomId) ? selectedRoomId : null;
   }, [rooms, selectedRoomId]);
 
   const selectedRoom = useMemo(

--- a/src/widgets/room-section/model/useRoomSelectionState.ts
+++ b/src/widgets/room-section/model/useRoomSelectionState.ts
@@ -8,17 +8,9 @@ interface UseRoomSelectionStateParams {
 export const useRoomSelectionState = ({ rooms }: UseRoomSelectionStateParams) => {
   const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
 
-  const effectiveSelectedRoomId = useMemo(() => {
-    if (selectedRoomId === null) {
-      return null;
-    }
-
-    return rooms.some((room) => room.id === selectedRoomId) ? selectedRoomId : null;
-  }, [rooms, selectedRoomId]);
-
   const selectedRoom = useMemo(
-    () => rooms.find((room) => room.id === effectiveSelectedRoomId) ?? null,
-    [rooms, effectiveSelectedRoomId],
+    () => rooms.find((room) => room.id === selectedRoomId) ?? null,
+    [rooms, selectedRoomId],
   );
 
   const handleSelectRoom = (roomId: number) => {
@@ -26,7 +18,7 @@ export const useRoomSelectionState = ({ rooms }: UseRoomSelectionStateParams) =>
   };
 
   return {
-    selectedRoomId: effectiveSelectedRoomId,
+    selectedRoomId,
     setSelectedRoomId,
     selectedRoom,
     handleSelectRoom,

--- a/src/widgets/room-section/ui/RoomDetailHeader.tsx
+++ b/src/widgets/room-section/ui/RoomDetailHeader.tsx
@@ -3,50 +3,18 @@ import type { RoomDetailDisplay, RoomDetailQueryState } from './RoomDetailPanel.
 
 interface RoomDetailHeaderProps {
   roomDetailQuery: RoomDetailQueryState;
-  isHostUser: boolean;
   detailDisplay: RoomDetailDisplay;
-  onEdit: () => void;
-  onDelete: () => Promise<void>;
 }
 
-const RoomDetailHeader = ({
-  roomDetailQuery,
-  isHostUser,
-  detailDisplay,
-  onEdit,
-  onDelete,
-}: RoomDetailHeaderProps) => (
-  <div className="flex flex-wrap items-start justify-between gap-4">
-    <div>
-      <div className="flex flex-wrap gap-2">
-        <RoomTypeBadge roomType={detailDisplay.detailType} />
-        <RoomStatusBadge status={detailDisplay.detailStatus} />
-      </div>
-      <h3 className="mt-4 text-[24px] font-bold tracking-[-0.03em] text-slate-900">
-        {roomDetailQuery.data?.title}
-      </h3>
-      <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-500">
-        {roomDetailQuery.data?.description || '방 소개가 아직 없어요.'}
-      </p>
+const RoomDetailHeader = ({ roomDetailQuery, detailDisplay }: RoomDetailHeaderProps) => (
+  <div>
+    <div className="flex flex-wrap gap-2">
+      <RoomTypeBadge roomType={detailDisplay.detailType} />
+      <RoomStatusBadge status={detailDisplay.detailStatus} />
     </div>
-    {isHostUser ? (
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onEdit}
-          className="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
-        >
-          수정
-        </button>
-        <button
-          type="button"
-          onClick={() => void onDelete()}
-          className="rounded-2xl bg-rose-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-rose-600"
-        >
-          삭제
-        </button>
-      </div>
-    ) : null}
+    <p className="mt-4 whitespace-pre-wrap text-sm leading-6 text-slate-500">
+      {roomDetailQuery.data?.description || '방 소개가 아직 없어요.'}
+    </p>
   </div>
 );
 

--- a/src/widgets/room-section/ui/RoomDetailPanel.tsx
+++ b/src/widgets/room-section/ui/RoomDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { PencilLine, Trash2 } from 'lucide-react';
 import RoomDetailError from './RoomDetailError';
 import RoomDetailHeader from './RoomDetailHeader';
 import RoomDetailLoading from './RoomDetailLoading';
@@ -16,23 +17,15 @@ const RoomDetailPanel = ({
   onDelete,
   onKickMember,
 }: RoomDetailPanelProps) => (
-  <article className="rounded-[32px] border border-slate-200/80 bg-white px-6 py-6 shadow-[0_16px_40px_rgba(15,23,42,0.06)] md:px-7">
+  <div>
     {roomDetailQuery.isLoading ? <RoomDetailLoading /> : null}
-    {roomDetailQuery.isError ? (
-      <RoomDetailError error={roomDetailQuery.error} />
-    ) : null}
+    {roomDetailQuery.isError ? <RoomDetailError error={roomDetailQuery.error} /> : null}
     {roomDetailQuery.data &&
     detailDisplay &&
     !roomDetailQuery.isLoading &&
     !roomDetailQuery.isError ? (
       <>
-        <RoomDetailHeader
-          roomDetailQuery={roomDetailQuery}
-          isHostUser={isHostUser}
-          detailDisplay={detailDisplay}
-          onEdit={onEdit}
-          onDelete={onDelete}
-        />
+        <RoomDetailHeader roomDetailQuery={roomDetailQuery} detailDisplay={detailDisplay} />
         <RoomDetailMeta roomDetailQuery={roomDetailQuery} detailDisplay={detailDisplay} />
         <RoomMemberSection
           roomMembersQuery={roomMembersQuery}
@@ -41,9 +34,30 @@ const RoomDetailPanel = ({
           currentUserId={currentUserId}
           onKickMember={onKickMember}
         />
+
+        {isHostUser ? (
+          <div className="mt-8 flex flex-col gap-3 border-t border-slate-100 pt-6 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onEdit}
+              className="inline-flex h-12 items-center justify-center gap-2 rounded-2xl border border-slate-200 px-5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+            >
+              <PencilLine className="h-4 w-4" />
+              수정
+            </button>
+            <button
+              type="button"
+              onClick={() => void onDelete()}
+              className="inline-flex h-12 items-center justify-center gap-2 rounded-2xl bg-rose-500 px-5 text-sm font-semibold text-white transition hover:bg-rose-600"
+            >
+              <Trash2 className="h-4 w-4" />
+              삭제
+            </button>
+          </div>
+        ) : null}
       </>
     ) : null}
-  </article>
+  </div>
 );
 
 export default RoomDetailPanel;

--- a/src/widgets/room-section/ui/RoomDetailPanel.types.ts
+++ b/src/widgets/room-section/ui/RoomDetailPanel.types.ts
@@ -1,13 +1,11 @@
-import type { MainRoom, RoomDetailResponse, RoomDetailStatus } from '@/entities/room';
+import type {
+  MainRoom,
+  RoomDetailResponse,
+  RoomDetailStatus,
+  RoomMemberResponse,
+} from '@/entities/room';
 
-export interface RoomMember {
-  userId: number;
-  nickname: string;
-  mbti: string;
-  profileImageUrl: string;
-  schoolName: string;
-  age: number;
-}
+export type RoomMember = RoomMemberResponse;
 
 export interface RoomMembersQueryState {
   isLoading: boolean;

--- a/src/widgets/room-section/ui/RoomMemberSection.tsx
+++ b/src/widgets/room-section/ui/RoomMemberSection.tsx
@@ -1,7 +1,4 @@
-import type {
-  RoomMember,
-  RoomMembersQueryState,
-} from './RoomDetailPanel.types';
+import type { RoomMember, RoomMembersQueryState } from './RoomDetailPanel.types';
 
 interface RoomMemberSectionProps {
   roomMembersQuery: RoomMembersQueryState;
@@ -24,15 +21,19 @@ const RoomMemberSection = ({
       <span className="text-xs text-slate-400">{roomMembers.length}명</span>
     </div>
     {roomMembersQuery.isLoading ? (
-      <div className="rounded-2xl bg-slate-50 px-4 py-5 text-sm text-slate-500">멤버 목록을 불러오는 중...</div>
+      <div className="rounded-2xl bg-slate-50 px-4 py-5 text-sm text-slate-500">
+        멤버 목록을 불러오는 중...
+      </div>
     ) : null}
     {roomMembersQuery.isError ? (
-      <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-5 text-sm text-rose-600">멤버 목록을 불러오지 못했어요.</div>
+      <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-5 text-sm text-rose-600">
+        멤버 목록을 불러오지 못했어요.
+      </div>
     ) : null}
     {!roomMembersQuery.isLoading && !roomMembersQuery.isError
       ? roomMembers.map((member) => (
           <div
-            key={member.userId}
+            key={member.id}
             className="flex items-center justify-between gap-4 rounded-2xl border border-slate-200 px-4 py-4"
           >
             <div className="flex min-w-0 items-center gap-4">
@@ -59,13 +60,13 @@ const RoomMemberSection = ({
                     {member.age}세
                   </span>
                 </div>
-                <p className="mt-1 truncate text-sm text-slate-500">{member.schoolName}</p>
+                <p className="mt-1 truncate text-sm text-slate-500">{member.schoolInfo}</p>
               </div>
             </div>
-            {isHostUser && currentUserId !== member.userId ? (
+            {isHostUser && currentUserId !== member.id ? (
               <button
                 type="button"
-                onClick={() => void onKickMember(member.userId)}
+                onClick={() => void onKickMember(member.id)}
                 className="shrink-0 rounded-xl bg-rose-50 px-3 py-1.5 text-xs font-semibold text-rose-600 transition hover:bg-rose-100"
               >
                 강퇴

--- a/src/widgets/room-section/ui/RoomSection.tsx
+++ b/src/widgets/room-section/ui/RoomSection.tsx
@@ -1,5 +1,7 @@
+import type { RoomSyncRequest } from '@/entities/room';
 import { RoomSummary } from '@/entities/room';
 import RoomEditorModal from '@/features/room/editor';
+import AppDialog from '@/shared/ui/modal/AppDialog';
 import { useRoomSection } from '../model/useRoomSection';
 import EmptyRoomState from './EmptyRoomState';
 import RoomActionBar from './RoomActionBar';
@@ -9,10 +11,16 @@ import RoomList from './RoomList';
 
 interface RoomSectionProps {
   onRequireLogin: () => void;
+  roomSyncRequest: RoomSyncRequest | null;
+  onRoomSyncHandled: () => void;
 }
 
-const RoomSection = ({ onRequireLogin }: RoomSectionProps) => {
-  const { filter, list, detail, dialogs, meta } = useRoomSection({ onRequireLogin });
+const RoomSection = ({ onRequireLogin, roomSyncRequest, onRoomSyncHandled }: RoomSectionProps) => {
+  const { filter, list, detail, dialogs, meta } = useRoomSection({
+    onRequireLogin,
+    roomSyncRequest,
+    onRoomSyncHandled,
+  });
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -39,7 +47,12 @@ const RoomSection = ({ onRequireLogin }: RoomSectionProps) => {
         />
       ) : null}
 
-      {meta.shouldShowDetail ? (
+      <AppDialog
+        isOpen={meta.shouldShowDetail}
+        onClose={() => list.setSelectedRoomId(null)}
+        title={detail.roomDetailQuery.data?.title ?? '점심 방 상세'}
+        maxWidthClassName="max-w-2xl"
+      >
         <RoomDetailPanel
           roomDetailQuery={detail.roomDetailQuery}
           roomMembersQuery={detail.roomMembersQuery}
@@ -51,7 +64,7 @@ const RoomSection = ({ onRequireLogin }: RoomSectionProps) => {
           onDelete={detail.onDelete}
           onKickMember={detail.onKickMember}
         />
-      ) : null}
+      </AppDialog>
 
       {meta.shouldShowEditModal ? (
         <RoomEditorModal


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 방 관련 API를 백엔드 문서에 맞게 연동 및 생성, 참여, 상세 조회 UX 관련 버그 수정

## ✨ 변경 사항 (Changes)

- 방 나가기 `POST`→`DELETE`로 수정
- 방 목록 페이지네이션 `size`→`limit`로 수정, 응답에 `hasNext` 추가
- 방 멤버 조회 응답 필드 수정 (`userId`→`id`, `schoolName`→`schoolInfo`, 누락된 `gender` 추가)
- 방 목록의 "모집중 인원"이 `NaN`으로 뜨던 문제 수정
- 방 생성 모달이 생성 성공 후 안 닫히던 문제 수정 (성공 콜백이 아예 연결 안 돼있었음)
- 방 생성 시 생성자가 자동으로 참여자로 반영되지 않던 문제 수정

## 📸 스크린샷 (Screenshots)

- 스크린샷 첨부

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 참고 사항 기재

## 🧐 이슈 (Related Issues)

- Closes #167 
