### PR TITLE
방 편집 폼 개선 및 UI/UX 개선

### DIFF
--- a/src/entities/room/model/mainRoom.ts
+++ b/src/entities/room/model/mainRoom.ts
@@ -8,4 +8,5 @@ export interface MainRoom {
   capacity: number;
   place: string;
   lunchAt: string;
+  status: 'OPEN' | 'FULL' | 'CLOSE' | 'COMPLETE';
 }

--- a/src/entities/room/model/roomMappers.ts
+++ b/src/entities/room/model/roomMappers.ts
@@ -24,6 +24,7 @@ export const toMainRoom = (room: RoomListItemResponse): MainRoom => ({
   capacity: room.maxMembersCount,
   place: room.place,
   lunchAt: formatLunchAt(room.lunchAt),
+  status: toDetailRoomStatus(room.status),
 });
 
 export const toDetailRoomType = (

--- a/src/entities/room/model/types.ts
+++ b/src/entities/room/model/types.ts
@@ -10,6 +10,7 @@ export interface RoomListItemResponse {
   place: string;
   lunchAt: string;
   currentMembersCount: number;
+  status: 'OPEN' | 'FULL' | 'CLOSE' | 'COMPLETE' | string;
 }
 
 export interface GetRoomsResponse {

--- a/src/entities/room/ui/RoomCard.tsx
+++ b/src/entities/room/ui/RoomCard.tsx
@@ -11,6 +11,7 @@ interface RoomCardProps {
   onClick: () => void;
   onActionClick: (roomId: number) => void;
   isActionPending?: boolean;
+  isInactive?: boolean;
   actionDisabled?: boolean;
   actionLabel?: string;
 }
@@ -21,11 +22,17 @@ const RoomCard = ({
   onClick,
   onActionClick,
   isActionPending = false,
+  isInactive = false,
   actionDisabled = false,
   actionLabel = '참여하기',
 }: RoomCardProps) => {
   const { badgeClassName, badgeLabel, buttonClassName, cardClassName, progressClassName } =
     roomTypeStyleMap[room.roomType];
+  const isCompleted = room.status === 'COMPLETE';
+  const inactiveButtonClassName = isCompleted
+    ? 'bg-sky-100 text-sky-700'
+    : 'bg-slate-200 text-slate-500';
+  const inactiveProgressClassName = isCompleted ? 'bg-sky-300' : 'bg-slate-300';
 
   return (
     <article
@@ -43,13 +50,17 @@ const RoomCard = ({
             badgeClassName={badgeClassName}
             badgeLabel={badgeLabel}
           />
-          <RoomCardCapacity room={room} progressClassName={progressClassName} />
+          <RoomCardCapacity
+            room={room}
+            progressClassName={isInactive ? inactiveProgressClassName : progressClassName}
+          />
           <RoomCardActionButton
             roomId={room.id}
             label={actionLabel}
             isPending={isActionPending}
+            isInactive={isInactive}
             disabled={actionDisabled}
-            buttonClassName={buttonClassName}
+            buttonClassName={isInactive ? inactiveButtonClassName : buttonClassName}
             onActionClick={onActionClick}
           />
         </div>

--- a/src/entities/room/ui/RoomCardActionButton.tsx
+++ b/src/entities/room/ui/RoomCardActionButton.tsx
@@ -5,6 +5,7 @@ interface RoomCardActionButtonProps {
   roomId: number;
   label: string;
   isPending?: boolean;
+  isInactive?: boolean;
   disabled?: boolean;
   buttonClassName: string;
   onActionClick: (roomId: number) => void;
@@ -14,6 +15,7 @@ const RoomCardActionButton = ({
   roomId,
   label,
   isPending = false,
+  isInactive = false,
   disabled = false,
   buttonClassName,
   onActionClick,
@@ -30,7 +32,8 @@ const RoomCardActionButton = ({
       disabled={disabled || isPending}
       className={cn(
         'mt-4 w-full rounded-2xl px-4 py-3.5 text-sm font-semibold transition',
-        disabled || isPending ? 'cursor-not-allowed opacity-70' : '',
+        disabled || isPending ? 'cursor-not-allowed' : '',
+        disabled && !isInactive ? 'opacity-70' : '',
         buttonClassName,
       )}
     >

--- a/src/features/room/editor/model/roomEditor.mappers.ts
+++ b/src/features/room/editor/model/roomEditor.mappers.ts
@@ -1,9 +1,5 @@
-import { formatKSTTime } from '@/shared/lib/date/formatKST';
+import { formatKSTDate, formatKSTTime } from '@/shared/lib/date/formatKST';
 import type { RoomEditorFormValues, RoomEditorSource } from './roomEditor.types';
-
-export function formatLunchAtForForm(lunchAt: string) {
-  return formatKSTTime(lunchAt);
-}
 
 export const toRoomEditorFormValues = (room: RoomEditorSource): RoomEditorFormValues => ({
   title: room.title,
@@ -11,7 +7,8 @@ export const toRoomEditorFormValues = (room: RoomEditorSource): RoomEditorFormVa
   roomType: room.roomType === 'MALE' || room.roomType === 'FEMALE' ? room.roomType : 'MIXED',
   capacity: String(room.maxMembersCount),
   place: room.place,
-  lunchAt: formatLunchAtForForm(room.lunchAt),
+  lunchDate: formatKSTDate(room.lunchAt),
+  lunchTime: formatKSTTime(room.lunchAt),
   minAge: String(room.minAge),
   maxAge: String(room.maxAge),
 });

--- a/src/features/room/editor/model/roomEditor.types.ts
+++ b/src/features/room/editor/model/roomEditor.types.ts
@@ -1,3 +1,4 @@
+import { getTodayKSTDateString } from '@/shared/lib/date/formatKST';
 import type { RoomDetailResponse } from '@/entities/room';
 
 export interface RoomEditorFormValues {
@@ -6,7 +7,8 @@ export interface RoomEditorFormValues {
   roomType: 'MIXED' | 'FEMALE' | 'MALE';
   capacity: string;
   place: string;
-  lunchAt: string;
+  lunchDate: string;
+  lunchTime: string;
   minAge: string;
   maxAge: string;
 }
@@ -22,15 +24,16 @@ export interface RoomEditorModalProps {
   onRequireLogin?: () => void;
 }
 
-export const INITIAL_ROOM_EDITOR_FORM_VALUES: RoomEditorFormValues = {
+export const getInitialRoomEditorFormValues = (): RoomEditorFormValues => ({
   title: '',
   description: '',
   roomType: 'MIXED',
   capacity: '4',
   place: '',
-  lunchAt: '12:00',
+  lunchDate: getTodayKSTDateString(),
+  lunchTime: '12:00',
   minAge: '20',
   maxAge: '24',
-};
+});
 
 export type RoomEditorSource = RoomDetailResponse;

--- a/src/features/room/editor/model/roomEditor.validators.ts
+++ b/src/features/room/editor/model/roomEditor.validators.ts
@@ -1,5 +1,10 @@
-import { nextKSTDateTimeISOString } from '@/shared/lib/date/formatKST';
+import { combineKSTDateTimeISOString } from '@/shared/lib/date/formatKST';
 import type { RoomEditorFormValues } from './roomEditor.types';
+
+export interface RoomEditorCurrentUser {
+  gender: 'MALE' | 'FEMALE';
+  age: number;
+}
 
 interface ParsedRoomEditorValues {
   title: string;
@@ -32,38 +37,26 @@ export const parseRequiredNumber = (value: string) => {
   return parsedValue;
 };
 
-export const toFutureLunchAt = (timeValue: string) => {
-  const trimmedValue = timeValue.trim();
+export const toValidLunchAt = (dateValue: string, timeValue: string) => {
+  const combined = combineKSTDateTimeISOString(dateValue, timeValue);
 
-  if (!/^\d{2}:\d{2}$/.test(trimmedValue)) {
+  if (!combined || new Date(combined).getTime() <= Date.now()) {
     return null;
   }
 
-  const [hours, minutes] = trimmedValue.split(':').map(Number);
-
-  if (
-    !Number.isInteger(hours) ||
-    !Number.isInteger(minutes) ||
-    hours < 0 ||
-    hours > 23 ||
-    minutes < 0 ||
-    minutes > 59
-  ) {
-    return null;
-  }
-
-  return nextKSTDateTimeISOString(hours, minutes);
+  return combined;
 };
 
 export const validateRoomEditorValues = (
   value: RoomEditorFormValues,
+  currentUser: RoomEditorCurrentUser,
 ): RoomEditorValidationResult => {
   const title = value.title.trim();
   const place = value.place.trim();
   const maxMembersCount = parseRequiredNumber(value.capacity);
   const minAge = parseRequiredNumber(value.minAge);
   const maxAge = parseRequiredNumber(value.maxAge);
-  const lunchAt = toFutureLunchAt(value.lunchAt);
+  const lunchAt = toValidLunchAt(value.lunchDate, value.lunchTime);
 
   if (!title) {
     return { error: '방 제목을 입력해 주세요.' };
@@ -85,8 +78,16 @@ export const validateRoomEditorValues = (
     return { error: '최소 나이는 최대 나이보다 클 수 없어요.' };
   }
 
+  if (value.roomType !== 'MIXED' && value.roomType !== currentUser.gender) {
+    return { error: '본인 성별과 맞지 않는 방 조건은 설정할 수 없어요.' };
+  }
+
+  if (currentUser.age < minAge || currentUser.age > maxAge) {
+    return { error: '본인 나이가 설정한 나이대에 포함되어야 해요.' };
+  }
+
   if (!lunchAt) {
-    return { error: '모임 시간을 올바르게 입력해 주세요.' };
+    return { error: '모임 날짜와 시간을 올바르게 입력해 주세요.' };
   }
 
   return {

--- a/src/features/room/editor/model/roomEditorSubmit.mappers.ts
+++ b/src/features/room/editor/model/roomEditorSubmit.mappers.ts
@@ -1,9 +1,12 @@
 import type { CreateRoomRequest, UpdateRoomRequest } from '@/entities/room';
 import type { RoomEditorFormValues } from './roomEditor.types';
-import { validateRoomEditorValues } from './roomEditor.validators';
+import { type RoomEditorCurrentUser, validateRoomEditorValues } from './roomEditor.validators';
 
-export const getRoomEditorPayload = (value: RoomEditorFormValues) => {
-  const validationResult = validateRoomEditorValues(value);
+export const getRoomEditorPayload = (
+  value: RoomEditorFormValues,
+  currentUser: RoomEditorCurrentUser,
+) => {
+  const validationResult = validateRoomEditorValues(value, currentUser);
 
   if (validationResult.error || !validationResult.parsed) {
     return validationResult;

--- a/src/features/room/editor/model/useCreateRoomSubmit.ts
+++ b/src/features/room/editor/model/useCreateRoomSubmit.ts
@@ -28,6 +28,7 @@ export const useCreateRoomSubmit = ({
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: roomQueryKeys.lists() }),
         queryClient.invalidateQueries({ queryKey: roomQueryKeys.details() }),
+        queryClient.invalidateQueries({ queryKey: roomQueryKeys.me() }),
       ]);
       onSuccess?.(room);
     },

--- a/src/features/room/editor/model/useRoomEditorForm.ts
+++ b/src/features/room/editor/model/useRoomEditorForm.ts
@@ -1,6 +1,6 @@
 import { useForm } from '@tanstack/react-form';
 import {
-  INITIAL_ROOM_EDITOR_FORM_VALUES,
+  getInitialRoomEditorFormValues,
   type RoomEditorModalProps,
 } from './roomEditor.types';
 import { useRoomEditorReset } from './useRoomEditorReset';
@@ -9,7 +9,7 @@ import { useRoomEditorSubmit } from './useRoomEditorSubmit';
 export const useRoomEditorForm = (props: RoomEditorModalProps) => {
   const submit = useRoomEditorSubmit(props);
   const roomEditorForm = useForm({
-    defaultValues: INITIAL_ROOM_EDITOR_FORM_VALUES,
+    defaultValues: getInitialRoomEditorFormValues(),
     onSubmit: async ({ value }) => {
       await submit.submitRoom(value);
     },

--- a/src/features/room/editor/model/useRoomEditorReset.ts
+++ b/src/features/room/editor/model/useRoomEditorReset.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import {
-  INITIAL_ROOM_EDITOR_FORM_VALUES,
+  getInitialRoomEditorFormValues,
   type RoomEditorFormValues,
   type RoomEditorModalProps,
 } from './roomEditor.types';
@@ -39,11 +39,11 @@ export const useRoomEditorReset = ({
       return;
     }
 
-    roomEditorForm.reset(initialValues ?? INITIAL_ROOM_EDITOR_FORM_VALUES);
+    roomEditorForm.reset(initialValues ?? getInitialRoomEditorFormValues());
   }, [initialValues, isOpen, roomEditorForm]);
 
   return () => {
-    roomEditorForm.reset(initialValues ?? INITIAL_ROOM_EDITOR_FORM_VALUES);
+    roomEditorForm.reset(initialValues ?? getInitialRoomEditorFormValues());
     createRoomMutation.reset();
     updateRoomMutation.reset();
     setSubmitMessage('');

--- a/src/features/room/editor/model/useRoomEditorSubmit.ts
+++ b/src/features/room/editor/model/useRoomEditorSubmit.ts
@@ -1,4 +1,7 @@
 import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { myUserQueryOptions } from '@/entities/user';
+import { calculateKoreanAge } from '@/shared/lib/date/calculateKoreanAge';
 import type { RoomEditorFormValues, RoomEditorModalProps } from './roomEditor.types';
 import { getRoomEditorPayload } from './roomEditorSubmit.mappers';
 import { useCreateRoomSubmit } from './useCreateRoomSubmit';
@@ -19,6 +22,7 @@ export const useRoomEditorSubmit = ({
   const [submitMessage, setSubmitMessage] = useState('');
   const [submitMessageTone, setSubmitMessageTone] = useState<'error' | 'success'>('success');
   const isEditMode = mode === 'edit';
+  const myUserQuery = useQuery(myUserQueryOptions());
   const createSubmit = useCreateRoomSubmit({
     onSuccess,
     onError,
@@ -31,7 +35,19 @@ export const useRoomEditorSubmit = ({
   });
 
   const submitRoom = async (value: RoomEditorFormValues) => {
-    const payloadResult = getRoomEditorPayload(value);
+    const currentUser = myUserQuery.data;
+
+    if (!currentUser) {
+      const message = '내 프로필 정보를 불러오지 못했어요. 잠시 후 다시 시도해 주세요.';
+      setSubmitMessage(message);
+      setSubmitMessageTone('error');
+      return;
+    }
+
+    const payloadResult = getRoomEditorPayload(value, {
+      gender: currentUser.gender,
+      age: calculateKoreanAge(currentUser.birthDate),
+    });
 
     if (!('payload' in payloadResult)) {
       setSubmitMessage(payloadResult.error);

--- a/src/features/room/editor/ui/RoomEditorConditionFields.tsx
+++ b/src/features/room/editor/ui/RoomEditorConditionFields.tsx
@@ -30,32 +30,56 @@ const RoomEditorConditionFields = ({
       )}
     />
 
-    {(['capacity', 'minAge', 'maxAge'] as const).map((name) => (
-      <roomEditor.roomEditorForm.Field
-        key={name}
-        name={name}
-        children={(field) => (
-          <label className="flex flex-col gap-2">
-            <span className="text-sm font-semibold text-slate-700">
-              {name === 'capacity'
-                ? '모집 인원'
-                : name === 'minAge'
-                  ? '최소 나이'
-                  : '최대 나이'}
-            </span>
+    <roomEditor.roomEditorForm.Field
+      name="capacity"
+      children={(field) => (
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-semibold text-slate-700">모집 인원</span>
+          <input
+            type="number"
+            min="1"
+            value={field.state.value}
+            onChange={(event) => updateRoomEditorFieldValue(field, roomEditor, event.target.value)}
+            className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+          />
+        </label>
+      )}
+    />
+
+    <label className="flex flex-col gap-2">
+      <span className="text-sm font-semibold text-slate-700">나이대</span>
+      <div className="flex items-center gap-2">
+        <roomEditor.roomEditorForm.Field
+          name="minAge"
+          children={(field) => (
             <input
               type="number"
-              min={name === 'capacity' ? '1' : '0'}
+              min="0"
               value={field.state.value}
               onChange={(event) =>
                 updateRoomEditorFieldValue(field, roomEditor, event.target.value)
               }
-              className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+              className="w-full min-w-0 rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
             />
-          </label>
-        )}
-      />
-    ))}
+          )}
+        />
+        <span className="shrink-0 text-sm text-slate-400">~</span>
+        <roomEditor.roomEditorForm.Field
+          name="maxAge"
+          children={(field) => (
+            <input
+              type="number"
+              min="0"
+              value={field.state.value}
+              onChange={(event) =>
+                updateRoomEditorFieldValue(field, roomEditor, event.target.value)
+              }
+              className="w-full min-w-0 rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
+            />
+          )}
+        />
+      </div>
+    </label>
   </>
 );
 

--- a/src/features/room/editor/ui/RoomEditorScheduleFields.tsx
+++ b/src/features/room/editor/ui/RoomEditorScheduleFields.tsx
@@ -23,7 +23,28 @@ const RoomEditorScheduleFields = ({
     />
 
     <roomEditor.roomEditorForm.Field
-      name="lunchAt"
+      name="lunchDate"
+      children={(field) => (
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-semibold text-slate-700">모임 날짜</span>
+          <input
+            type="date"
+            value={field.state.value}
+            disabled={roomEditor.isEditMode}
+            onChange={(event) =>
+              updateRoomEditorFieldValue(field, roomEditor, event.target.value)
+            }
+            className="rounded-2xl border border-slate-200 px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400"
+          />
+          {roomEditor.isEditMode ? (
+            <span className="text-xs text-slate-400">모임 날짜는 방 생성 후 변경할 수 없어요.</span>
+          ) : null}
+        </label>
+      )}
+    />
+
+    <roomEditor.roomEditorForm.Field
+      name="lunchTime"
       children={(field) => (
         <label className="flex flex-col gap-2">
           <span className="text-sm font-semibold text-slate-700">모임 시간</span>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -832,6 +832,7 @@ const toRoomListItem = (room: RoomDetailResponse): RoomListItemResponse => ({
   place: room.place,
   lunchAt: room.lunchAt,
   currentMembersCount: room.currentMembersCount,
+  status: room.status,
 });
 
 const getRoom = (roomId: number) => rooms.find((room) => room.id === roomId);

--- a/src/pages/main/ui/layout/main-tab-section/ui/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/main-tab-section/ui/MainTabSection.tsx
@@ -2,9 +2,10 @@ import { useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import type { PostSyncRequest } from '@/entities/post';
-import type { RoomSyncRequest } from '@/entities/room';
+import { myRoomQueryOptions, type RoomSyncRequest } from '@/entities/room';
 import { myUserQueryOptions } from '@/entities/user';
 import { lunchMenuListQueryOptions, lunchMenuQueryKeys, type MainLunchMenu } from '@/entities/lunch-menu';
+import { authSessionSelectors, useAuthSessionStore } from '@/shared/lib/auth/session';
 import type { MainTab } from '../../main-tabs/model/types';
 import LunchSection from '@/widgets/lunch-section';
 import PostSection from '@/widgets/post-section';
@@ -52,6 +53,10 @@ const MainTabSection = ({
   const isPostTab = activeTab === 'POST';
   const myUserQuery = useQuery(myUserQueryOptions());
   const isAdmin = myUserQuery.data?.role === 'ADMIN';
+  const isAuthed = useAuthSessionStore(authSessionSelectors.isAuthenticated);
+  const myRoomQuery = useQuery({ ...myRoomQueryOptions(), enabled: isAuthed });
+  const hasJoinedRoom = myRoomQuery.isSuccess;
+  const isCreateRoomDisabled = isRoomTab && (!isAuthed || hasJoinedRoom);
   const lunchMenusQuery = useQuery(lunchMenuListQueryOptions());
   const lunchMenus = useMemo(() => lunchMenusQuery.data ?? [], [lunchMenusQuery.data]);
 
@@ -132,14 +137,22 @@ const MainTabSection = ({
         </div>
 
         {isRoomTab || isPostTab ? (
-          <button
-            type="button"
-            onClick={isRoomTab ? onCreateRoomClick : onCreatePostClick}
-            className="inline-flex items-center justify-center gap-2 rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
-          >
-            <Plus className="h-4 w-4" />
-            {isRoomTab ? '방 만들기' : '게시글 작성'}
-          </button>
+          <div className="flex flex-col items-end gap-2">
+            <button
+              type="button"
+              onClick={isRoomTab ? onCreateRoomClick : onCreatePostClick}
+              disabled={isCreateRoomDisabled}
+              className="inline-flex items-center justify-center gap-2 rounded-2xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:hover:bg-slate-300"
+            >
+              <Plus className="h-4 w-4" />
+              {isRoomTab ? '방 만들기' : '게시글 작성'}
+            </button>
+            {isCreateRoomDisabled ? (
+              <p className="text-xs text-slate-400">
+                {!isAuthed ? '로그인 후 이용할 수 있어요.' : '이미 참여중인 방이 있어요.'}
+              </p>
+            ) : null}
+          </div>
         ) : null}
       </div>
 

--- a/src/shared/lib/date/calculateKoreanAge.ts
+++ b/src/shared/lib/date/calculateKoreanAge.ts
@@ -1,0 +1,9 @@
+import { getTodayKSTDateString } from './formatKST';
+
+/** 한국식(세는) 나이: 생일과 무관하게 매년 1월 1일에 한 살씩 증가한다. */
+export const calculateKoreanAge = (birthDate: string): number => {
+  const birthYear = Number(birthDate.slice(0, 4));
+  const todayYear = Number(getTodayKSTDateString().slice(0, 4));
+
+  return todayYear - birthYear + 1;
+};

--- a/src/shared/lib/date/formatKST.ts
+++ b/src/shared/lib/date/formatKST.ts
@@ -9,40 +9,12 @@ const kstTimeFormatter = new Intl.DateTimeFormat('ko-KR', {
   hourCycle: 'h23',
 });
 
-const kstPartsFormatter = new Intl.DateTimeFormat('en-CA', {
+const kstDateFormatter = new Intl.DateTimeFormat('en-CA', {
   timeZone: KST_TIME_ZONE,
   year: 'numeric',
   month: '2-digit',
   day: '2-digit',
-  hour: '2-digit',
-  minute: '2-digit',
-  hourCycle: 'h23',
 });
-
-interface KSTDateParts {
-  year: number;
-  month: number;
-  day: number;
-  hour: number;
-  minute: number;
-}
-
-const getKSTParts = (date: Date): KSTDateParts => {
-  const lookup = Object.fromEntries(
-    kstPartsFormatter.formatToParts(date).map((part) => [part.type, part.value]),
-  );
-
-  return {
-    year: Number(lookup.year),
-    month: Number(lookup.month),
-    day: Number(lookup.day),
-    hour: Number(lookup.hour),
-    minute: Number(lookup.minute),
-  };
-};
-
-const kstPartsToUTCDate = ({ year, month, day, hour, minute }: KSTDateParts): Date =>
-  new Date(Date.UTC(year, month - 1, day, hour - KST_OFFSET_HOURS, minute, 0, 0));
 
 export const formatKSTTime = (isoString: string): string => {
   const date = new Date(isoString);
@@ -54,25 +26,54 @@ export const formatKSTTime = (isoString: string): string => {
   return kstTimeFormatter.format(date);
 };
 
-/**
- * Interprets `hours:minutes` as a KST wall-clock time and returns the ISO
- * string for its next occurrence (today if still ahead of now, otherwise
- * tomorrow) — independent of the browser's own timezone.
- */
-export const nextKSTDateTimeISOString = (hours: number, minutes: number): string => {
-  const now = new Date();
-  const nowKSTParts = getKSTParts(now);
+/** Returns the KST calendar date of an ISO instant as "YYYY-MM-DD". */
+export const formatKSTDate = (isoString: string): string => {
+  const date = new Date(isoString);
 
-  const todayTarget = kstPartsToUTCDate({ ...nowKSTParts, hour: hours, minute: minutes });
-
-  if (todayTarget.getTime() > now.getTime()) {
-    return todayTarget.toISOString();
+  if (Number.isNaN(date.getTime())) {
+    return isoString;
   }
 
-  return kstPartsToUTCDate({
-    ...nowKSTParts,
-    day: nowKSTParts.day + 1,
-    hour: hours,
-    minute: minutes,
-  }).toISOString();
+  return kstDateFormatter.format(date);
+};
+
+/** Today's KST calendar date as "YYYY-MM-DD" — for default form values. */
+export const getTodayKSTDateString = (): string => kstDateFormatter.format(new Date());
+
+/**
+ * Combines a "YYYY-MM-DD" date and "HH:MM" time — both interpreted as KST
+ * wall-clock values — into the equivalent ISO instant, independent of the
+ * browser's own timezone. Returns null when either input is malformed.
+ */
+export const combineKSTDateTimeISOString = (
+  dateString: string,
+  timeString: string,
+): string | null => {
+  const dateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString.trim());
+  const timeMatch = /^(\d{2}):(\d{2})$/.exec(timeString.trim());
+
+  if (!dateMatch || !timeMatch) {
+    return null;
+  }
+
+  const [, year, month, day] = dateMatch;
+  const [, hour, minute] = timeMatch;
+
+  const date = new Date(
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour) - KST_OFFSET_HOURS,
+      Number(minute),
+      0,
+      0,
+    ),
+  );
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
 };

--- a/src/widgets/room-section/model/deriveRoomCardActionState.ts
+++ b/src/widgets/room-section/model/deriveRoomCardActionState.ts
@@ -28,9 +28,21 @@ export const deriveRoomCardActionState = ({
     (isLeavePending && pendingLeaveRoomId === room.id);
   const isJoinedRoom = joinedRoomId === room.id;
   const isFullRoom = room.currentCount >= room.capacity;
+  const isRoomInactive = room.status === 'CLOSE' || room.status === 'COMPLETE';
+
+  if (isRoomInactive) {
+    return {
+      isActionPending: false,
+      isInactive: true,
+      actionDisabled: true,
+      actionLabel: room.status === 'COMPLETE' ? '완료된 방이에요' : '종료된 방이에요',
+      onActionClick: handleJoinRoom,
+    };
+  }
 
   return {
     isActionPending,
+    isInactive: false,
     actionDisabled: isJoinedRoom
       ? isActionPending
       : isFullRoom || isActionPending || hasJoinedActiveRoom,

--- a/src/widgets/room-section/model/useRoomMembers.ts
+++ b/src/widgets/room-section/model/useRoomMembers.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { roomMembersQueryOptions, type RoomDetailResponse } from '@/entities/room';
 import { myUserQueryOptions } from '@/entities/user';
-import { isAuthenticated } from '@/shared/lib/auth/session';
+import { authSessionSelectors, useAuthSessionStore } from '@/shared/lib/auth/session';
 
 interface UseRoomMembersParams {
   selectedRoomId: number | null;
@@ -12,7 +12,7 @@ export const useRoomMembers = ({
   selectedRoomId,
   selectedRoomDetail,
 }: UseRoomMembersParams) => {
-  const isLoggedIn = isAuthenticated();
+  const isLoggedIn = useAuthSessionStore(authSessionSelectors.isAuthenticated);
 
   const currentUserQuery = useQuery({
     ...myUserQueryOptions(),

--- a/src/widgets/room-section/model/useRoomSectionData.ts
+++ b/src/widgets/room-section/model/useRoomSectionData.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { myRoomQueryOptions } from '@/entities/room';
-import { isAuthenticated } from '@/shared/lib/auth/session';
+import { authSessionSelectors, useAuthSessionStore } from '@/shared/lib/auth/session';
 import { useInfiniteRooms } from './useInfiniteRooms';
 import { useRoomEditTarget } from './useRoomEditTarget';
 import { useRoomMembers } from './useRoomMembers';
@@ -22,9 +22,10 @@ export const useRoomSectionData = () => {
     selectedRoomId: roomSelectionState.selectedRoomId,
     selectedRoomDetail: selectedRoomDetailState.selectedRoomDetail,
   });
+  const isAuthed = useAuthSessionStore(authSessionSelectors.isAuthenticated);
   const myRoomQuery = useQuery({
     ...myRoomQueryOptions(),
-    enabled: isAuthenticated(),
+    enabled: isAuthed,
   });
 
   return {

--- a/src/widgets/room-section/ui/RoomDetailPanel.tsx
+++ b/src/widgets/room-section/ui/RoomDetailPanel.tsx
@@ -22,6 +22,10 @@ const RoomDetailPanel = ({
   onRequestComplete,
   onRequestLeave,
 }: RoomDetailPanelProps) => {
+  const isMemberOfThisRoom = roomMembers.some((member) => member.id === currentUserId);
+  const isRoomActive =
+    detailDisplay?.detailStatus === 'OPEN' || detailDisplay?.detailStatus === 'FULL';
+
   return (
     <div>
       {roomDetailQuery.isLoading ? <RoomDetailLoading /> : null}
@@ -37,12 +41,25 @@ const RoomDetailPanel = ({
             roomMembersQuery={roomMembersQuery}
             roomMembers={roomMembers}
             isHostUser={isHostUser}
+            isRoomActive={isRoomActive}
             currentUserId={currentUserId}
             onRequestKick={onRequestKick}
           />
 
           <div className="mt-8 flex flex-col gap-3 border-t border-slate-100 pt-6 sm:flex-row sm:justify-end">
-            {joinedRoomId !== null ? (
+            {!isRoomActive ? (
+              <button
+                type="button"
+                disabled
+                className={`inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl px-5 text-sm font-semibold ${
+                  detailDisplay.detailStatus === 'COMPLETE'
+                    ? 'bg-sky-100 text-sky-700'
+                    : 'bg-slate-200 text-slate-500'
+                }`}
+              >
+                {detailDisplay.detailStatus === 'COMPLETE' ? '완료된 방이에요' : '종료된 방이에요'}
+              </button>
+            ) : isMemberOfThisRoom ? (
               <button
                 type="button"
                 onClick={onRequestLeave}
@@ -51,7 +68,7 @@ const RoomDetailPanel = ({
                 <LogOut className="h-4 w-4" />
                 나가기
               </button>
-            ) : (
+            ) : joinedRoomId === null ? (
               <button
                 type="button"
                 onClick={onJoin}
@@ -61,20 +78,26 @@ const RoomDetailPanel = ({
                 <LogIn className="h-4 w-4" />
                 {isJoinPending ? '참여 중...' : '참여하기'}
               </button>
+            ) : (
+              <button
+                type="button"
+                disabled
+                className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl bg-slate-200 px-5 text-sm font-semibold text-slate-500"
+              >
+                다른 방에 참여 중
+              </button>
             )}
           </div>
-          {isHostUser ? (
+          {isHostUser && isRoomActive ? (
             <div className="mt-8 flex flex-col gap-3 border-t border-slate-100 pt-6 sm:flex-row sm:justify-end">
-              {detailDisplay.detailStatus === 'OPEN' || detailDisplay.detailStatus === 'FULL' ? (
-                <button
-                  type="button"
-                  onClick={onRequestComplete}
-                  className="inline-flex h-12 items-center justify-center gap-2 rounded-2xl border border-sky-200 px-5 text-sm font-semibold text-sky-700 transition hover:bg-sky-50"
-                >
-                  <CheckCircle2 className="h-4 w-4" />
-                  완료 처리
-                </button>
-              ) : null}
+              <button
+                type="button"
+                onClick={onRequestComplete}
+                className="inline-flex h-12 items-center justify-center gap-2 rounded-2xl border border-sky-200 px-5 text-sm font-semibold text-sky-700 transition hover:bg-sky-50"
+              >
+                <CheckCircle2 className="h-4 w-4" />
+                완료 처리
+              </button>
               <button
                 type="button"
                 onClick={onEdit}

--- a/src/widgets/room-section/ui/RoomList.tsx
+++ b/src/widgets/room-section/ui/RoomList.tsx
@@ -4,6 +4,7 @@ import SelectableRoomCard from './SelectableRoomCard';
 
 interface RoomCardActionState {
   isActionPending: boolean;
+  isInactive: boolean;
   actionDisabled: boolean;
   actionLabel: string;
   onActionClick: (roomId: number) => void;

--- a/src/widgets/room-section/ui/RoomMemberSection.tsx
+++ b/src/widgets/room-section/ui/RoomMemberSection.tsx
@@ -5,6 +5,7 @@ interface RoomMemberSectionProps {
   roomMembersQuery: RoomMembersQueryState;
   roomMembers: RoomMember[];
   isHostUser: boolean;
+  isRoomActive: boolean;
   currentUserId: number | null;
   onRequestKick: (userId: number, nickname: string) => void;
 }
@@ -13,6 +14,7 @@ const RoomMemberSection = ({
   roomMembersQuery,
   roomMembers,
   isHostUser,
+  isRoomActive,
   currentUserId,
   onRequestKick,
 }: RoomMemberSectionProps) => (
@@ -52,7 +54,7 @@ const RoomMemberSection = ({
                 <p className="mt-1 truncate text-sm text-slate-500">{member.schoolInfo}</p>
               </div>
             </div>
-            {isHostUser && currentUserId !== member.id ? (
+            {isHostUser && isRoomActive && currentUserId !== member.id ? (
               <button
                 type="button"
                 onClick={() => onRequestKick(member.id, member.nickname)}

--- a/src/widgets/room-section/ui/RoomQuickJoinBar.tsx
+++ b/src/widgets/room-section/ui/RoomQuickJoinBar.tsx
@@ -1,4 +1,5 @@
 import { Sparkles } from 'lucide-react';
+import { authSessionSelectors, useAuthSessionStore } from '@/shared/lib/auth/session';
 
 interface RoomQuickJoinBarProps {
   myRoomId: number | null;
@@ -12,33 +13,39 @@ const RoomQuickJoinBar = ({
   isQuickJoinPending,
   onQuickJoin,
   onViewMyRoom,
-}: RoomQuickJoinBarProps) => (
-  <section className="flex items-center justify-between rounded-[24px] border border-slate-200/80 bg-white px-5 py-4 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
-    <div className="flex items-center gap-2 text-sm text-slate-600">
-      <Sparkles className="h-4 w-4 text-amber-500" />
-      {myRoomId !== null
-        ? '이미 참여중인 방이 있어요.'
-        : '조건에 맞는 방에 바로 참여해보세요.'}
-    </div>
-    {myRoomId !== null ? (
-      <button
-        type="button"
-        onClick={() => onViewMyRoom(myRoomId)}
-        className="inline-flex h-10 items-center justify-center rounded-full border border-slate-200 px-4 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-      >
-        내 방 보기
-      </button>
-    ) : (
-      <button
-        type="button"
-        onClick={() => void onQuickJoin()}
-        disabled={isQuickJoinPending}
-        className="inline-flex h-10 items-center justify-center rounded-full bg-slate-900 px-4 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {isQuickJoinPending ? '참여 중...' : '빠른 참여'}
-      </button>
-    )}
-  </section>
-);
+}: RoomQuickJoinBarProps) => {
+  const isAuthed = useAuthSessionStore(authSessionSelectors.isAuthenticated);
+
+  return (
+    <section className="flex items-center justify-between rounded-[24px] border border-slate-200/80 bg-white px-5 py-4 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+      <div className="flex items-center gap-2 text-sm text-slate-600">
+        <Sparkles className="h-4 w-4 text-amber-500" />
+        {!isAuthed
+          ? '로그인 후 빠른 참여를 이용할 수 있어요.'
+          : myRoomId !== null
+            ? '이미 참여중인 방이 있어요.'
+            : '조건에 맞는 방에 바로 참여해보세요.'}
+      </div>
+      {myRoomId !== null ? (
+        <button
+          type="button"
+          onClick={() => onViewMyRoom(myRoomId)}
+          className="inline-flex h-10 items-center justify-center rounded-full border border-slate-200 px-4 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+        >
+          내 방 보기
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={() => void onQuickJoin()}
+          disabled={isQuickJoinPending || !isAuthed}
+          className="inline-flex h-10 items-center justify-center rounded-full bg-slate-900 px-4 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isQuickJoinPending ? '참여 중...' : '빠른 참여'}
+        </button>
+      )}
+    </section>
+  );
+};
 
 export default RoomQuickJoinBar;

--- a/src/widgets/room-section/ui/SelectableRoomCard.tsx
+++ b/src/widgets/room-section/ui/SelectableRoomCard.tsx
@@ -2,6 +2,7 @@ import { RoomCard as EntityRoomCard, type MainRoom } from '@/entities/room';
 
 interface RoomCardActionState {
   isActionPending: boolean;
+  isInactive: boolean;
   actionDisabled: boolean;
   actionLabel: string;
   onActionClick: (roomId: number) => void;
@@ -26,6 +27,7 @@ const SelectableRoomCard = ({
     onClick={() => setSelectedRoomId(room.id)}
     onActionClick={roomCardActionState.onActionClick}
     isActionPending={roomCardActionState.isActionPending}
+    isInactive={roomCardActionState.isInactive}
     actionDisabled={roomCardActionState.actionDisabled}
     actionLabel={roomCardActionState.actionLabel}
   />


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 방 생성/수정 폼의 나이 필드(최소/최대)를 하나로 통합하고, 모임 날짜 필드를 추가해 임의 날짜의 방을 생성할 수 있도록 개선
- 방 생성 시 방 조건(성별/나이대)이 작성자 본인 프로필과 맞지 않으면 생성하지 못하도록 검증 추가
- 종료(CLOSE)/완료(COMPLETE) 상태인 방에서 참여·수정·삭제·강퇴가 불가능하도록 막고, 목록/상세 양쪽에 상태별 색상과 안내 문구를 우선 노출하도록 UX 개선

## ✨ 변경 사항 (Changes)

- KST 시간 유틸(`formatKST.ts`) 정리 및 한국 나이(세는 나이) 계산 유틸(`calculateKoreanAge.ts`) 추가
- 방 편집 폼: 최소/최대 나이 필드를 하나의 나이대 필드로 통합, 모임 날짜 필드 추가(수정 시에는 날짜 변경 불가, 시간만 변경 가능), 생성자 성별/나이 조건 검증 로직 추가
- `RoomListItemResponse`/`MainRoom`에 `status` 필드 반영, 종료/완료 방은 목록 카드·상세 패널에서 참여·수정·삭제·강퇴 액션을 비활성화하고 상태별 색상(종료: 회색, 완료: 완료 버튼과 동일한 sky 색상) 및 안내 문구를 우선 노출

## 📸 스크린샷 (Screenshots)

- 스크린샷 첨부

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 참고 사항 기재

## 🧐 이슈 (Related Issues)

- Closes #172 
