### PR TITLE
feat: (#175) 학식 메뉴 API 연동

### DIFF
--- a/src/entities/lunch-menu/api/lunchMenuList.ts
+++ b/src/entities/lunch-menu/api/lunchMenuList.ts
@@ -1,8 +1,12 @@
 import client from '@/shared/api/client';
 import type { MainLunchMenu } from '../model/types';
 
-export async function getLunchMenus(): Promise<MainLunchMenu[]> {
-  const response = await client.get<MainLunchMenu[]>('/api/v1/lunch-menus');
+interface GetMealMenusResponse {
+  items: MainLunchMenu[];
+}
 
-  return response.data;
+export async function getLunchMenus(): Promise<MainLunchMenu[]> {
+  const response = await client.get<GetMealMenusResponse>('/api/v1/meal-menus');
+
+  return response.data.items;
 }

--- a/src/entities/lunch-menu/api/lunchMenuQueryKeys.ts
+++ b/src/entities/lunch-menu/api/lunchMenuQueryKeys.ts
@@ -1,4 +1,8 @@
+import type { LunchReactionType } from '../model/types';
+
 export const lunchMenuQueryKeys = {
   all: () => ['lunchMenus'] as const,
   lists: () => [...lunchMenuQueryKeys.all(), 'list'] as const,
+  rankings: (actionType: NonNullable<LunchReactionType>) =>
+    [...lunchMenuQueryKeys.all(), 'rankings', actionType] as const,
 };

--- a/src/entities/lunch-menu/api/lunchMenuRankings.ts
+++ b/src/entities/lunch-menu/api/lunchMenuRankings.ts
@@ -1,0 +1,16 @@
+import client from '@/shared/api/client';
+import type { LunchReactionType, MainLunchMenu } from '../model/types';
+
+interface GetMealMenusResponse {
+  items: MainLunchMenu[];
+}
+
+export async function getLunchMenuRankings(
+  actionType: NonNullable<LunchReactionType>,
+): Promise<MainLunchMenu[]> {
+  const response = await client.get<GetMealMenusResponse>('/api/v1/meal-menus/rankings', {
+    params: { actionType },
+  });
+
+  return response.data.items;
+}

--- a/src/entities/lunch-menu/api/lunchMenuRankingsQueries.ts
+++ b/src/entities/lunch-menu/api/lunchMenuRankingsQueries.ts
@@ -1,0 +1,10 @@
+import { queryOptions } from '@tanstack/react-query';
+import type { LunchReactionType } from '../model/types';
+import { getLunchMenuRankings } from './lunchMenuRankings';
+import { lunchMenuQueryKeys } from './lunchMenuQueryKeys';
+
+export const lunchMenuRankingsQueryOptions = (actionType: NonNullable<LunchReactionType>) =>
+  queryOptions({
+    queryKey: lunchMenuQueryKeys.rankings(actionType),
+    queryFn: () => getLunchMenuRankings(actionType),
+  });

--- a/src/entities/lunch-menu/index.ts
+++ b/src/entities/lunch-menu/index.ts
@@ -1,5 +1,8 @@
-export type { LunchMealType, MainLunchMenu } from './model/types';
+export type { LunchMealType, LunchReactionType, MainLunchMenu } from './model/types';
 export { LUNCH_MEAL_TYPE_OPTIONS, lunchMealTypeLabelMap } from './model/lunchMealType';
+export { patchLunchMenuReaction } from './model/lunchMenuCache';
 export { getLunchMenus } from './api/lunchMenuList';
 export { lunchMenuListQueryOptions } from './api/lunchMenuListQueries';
+export { getLunchMenuRankings } from './api/lunchMenuRankings';
+export { lunchMenuRankingsQueryOptions } from './api/lunchMenuRankingsQueries';
 export { lunchMenuQueryKeys } from './api/lunchMenuQueryKeys';

--- a/src/entities/lunch-menu/model/lunchMenuCache.ts
+++ b/src/entities/lunch-menu/model/lunchMenuCache.ts
@@ -1,0 +1,12 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { lunchMenuQueryKeys } from '../api/lunchMenuQueryKeys';
+import type { MainLunchMenu } from './types';
+
+export const patchLunchMenuReaction = (
+  queryClient: QueryClient,
+  menuId: number,
+  patch: Pick<MainLunchMenu, 'likeCount' | 'dislikeCount' | 'myReaction'>,
+) =>
+  queryClient.setQueriesData<MainLunchMenu[]>({ queryKey: lunchMenuQueryKeys.all() }, (menus) =>
+    menus?.map((menu) => (menu.id === menuId ? { ...menu, ...patch } : menu)),
+  );

--- a/src/entities/lunch-menu/model/types.ts
+++ b/src/entities/lunch-menu/model/types.ts
@@ -1,15 +1,15 @@
 export type LunchMealType = 'BREAKFAST' | 'LUNCH' | 'DINNER';
+export type LunchReactionType = 'LIKE' | 'DISLIKE' | null;
 
 export interface MainLunchMenu {
   id: number;
   mealType: LunchMealType;
   menuName: string;
-  price: number;
-  calorie: number;
+  price: number | null;
+  calorie: number | null;
   schoolInfo: string;
   components: string[];
   likeCount: number;
   dislikeCount: number;
-  likedByMe?: boolean;
-  dislikedByMe?: boolean;
+  myReaction: LunchReactionType;
 }

--- a/src/features/auth/loginForm.tsx
+++ b/src/features/auth/loginForm.tsx
@@ -7,7 +7,7 @@ const LoginForm = () => {
   const navigate = useNavigate();
   const { emailField, passwordField, errors, isPending, errorMessage, onSubmit } = useLoginForm({
     onSuccess: () => {
-      window.location.href = '/profile';
+      navigate('/profile');
     },
   });
 

--- a/src/features/lunch/delete/api.ts
+++ b/src/features/lunch/delete/api.ts
@@ -1,5 +1,5 @@
 import client from '@/shared/api/client';
 
 export async function deleteLunchMenu(menuId: number): Promise<void> {
-  await client.delete(`/api/v1/lunch-menus/${menuId}`);
+  await client.delete(`/api/v1/meal-menus/${menuId}`);
 }

--- a/src/features/lunch/delete/model/useDeleteLunchMenuAction.ts
+++ b/src/features/lunch/delete/model/useDeleteLunchMenuAction.ts
@@ -31,8 +31,9 @@ export const useDeleteLunchMenuAction = ({
     try {
       await deleteLunchMenuMutation.mutateAsync(targetMenu.id);
 
-      queryClient.setQueryData<MainLunchMenu[]>(lunchMenuQueryKeys.lists(), (currentMenus) =>
-        (currentMenus ?? []).filter((menu) => menu.id !== targetMenu.id),
+      queryClient.setQueriesData<MainLunchMenu[]>(
+        { queryKey: lunchMenuQueryKeys.all() },
+        (currentMenus) => currentMenus?.filter((menu) => menu.id !== targetMenu.id),
       );
 
       if (selectedLunchMenuId === targetMenu.id) {
@@ -41,7 +42,7 @@ export const useDeleteLunchMenuAction = ({
 
       setDeleteErrorMessage('');
       closeDeleteConfirm();
-      await queryClient.invalidateQueries({ queryKey: lunchMenuQueryKeys.lists() });
+      await queryClient.invalidateQueries({ queryKey: lunchMenuQueryKeys.all() });
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 401) {
         setDeleteErrorMessage('로그인 후 이용할 수 있어요.');

--- a/src/features/lunch/editor/api.ts
+++ b/src/features/lunch/editor/api.ts
@@ -4,7 +4,7 @@ import type { LunchMenuEditorPayload, LunchMenuEditorResult } from './model/lunc
 export async function createLunchMenu(
   payload: LunchMenuEditorPayload,
 ): Promise<LunchMenuEditorResult> {
-  const response = await client.post<LunchMenuEditorResult>('/api/v1/lunch-menus', payload);
+  const response = await client.post<LunchMenuEditorResult>('/api/v1/meal-menus', payload);
 
   return response.data;
 }
@@ -14,7 +14,7 @@ export async function updateLunchMenu(
   payload: LunchMenuEditorPayload,
 ): Promise<LunchMenuEditorResult> {
   const response = await client.patch<LunchMenuEditorResult>(
-    `/api/v1/lunch-menus/${menuId}`,
+    `/api/v1/meal-menus/${menuId}`,
     payload,
   );
 

--- a/src/features/lunch/editor/model/lunchMenuEditor.types.ts
+++ b/src/features/lunch/editor/model/lunchMenuEditor.types.ts
@@ -15,11 +15,19 @@ export interface LunchMenuEditorPayload {
   price: number;
   calorie: number;
   schoolInfo: string;
-  components: string[];
+  components: string;
 }
 
-export interface LunchMenuEditorResult extends LunchMenuEditorPayload {
+export interface LunchMenuEditorResult {
   id: number;
+  mealType: LunchMealType;
+  menuName: string;
+  price: number | null;
+  calorie: number | null;
+  schoolInfo: string;
+  components: string[];
+  likeCount: number;
+  dislikeCount: number;
 }
 
 export interface LunchMenuEditorModalProps {

--- a/src/features/lunch/editor/model/useLunchMenuEditorForm.ts
+++ b/src/features/lunch/editor/model/useLunchMenuEditorForm.ts
@@ -38,7 +38,7 @@ export const useLunchMenuEditorForm = ({
   }, [isOpen]);
 
   const invalidateLunchMenus = () =>
-    queryClient.invalidateQueries({ queryKey: lunchMenuQueryKeys.lists() });
+    queryClient.invalidateQueries({ queryKey: lunchMenuQueryKeys.all() });
 
   const createMutation = useMutation({
     mutationFn: createLunchMenu,
@@ -82,7 +82,8 @@ export const useLunchMenuEditorForm = ({
       components: values.componentsText
         .split(',')
         .map((item) => item.trim())
-        .filter(Boolean),
+        .filter(Boolean)
+        .join(' '),
     };
 
     try {

--- a/src/features/lunch/react/api.ts
+++ b/src/features/lunch/react/api.ts
@@ -1,0 +1,32 @@
+import client from '@/shared/api/client';
+import type { LunchReactionType } from '@/entities/lunch-menu';
+
+export interface LunchMenuReactionResult {
+  actionType: LunchReactionType;
+  likeCount: number;
+  dislikeCount: number;
+}
+
+export async function likeLunchMenu(menuId: number): Promise<LunchMenuReactionResult> {
+  const response = await client.post<LunchMenuReactionResult>(
+    `/api/v1/meal-menus/${menuId}/like`,
+  );
+
+  return response.data;
+}
+
+export async function dislikeLunchMenu(menuId: number): Promise<LunchMenuReactionResult> {
+  const response = await client.post<LunchMenuReactionResult>(
+    `/api/v1/meal-menus/${menuId}/dislike`,
+  );
+
+  return response.data;
+}
+
+export async function cancelLunchMenuReaction(menuId: number): Promise<LunchMenuReactionResult> {
+  const response = await client.delete<LunchMenuReactionResult>(
+    `/api/v1/meal-menus/${menuId}/reaction`,
+  );
+
+  return response.data;
+}

--- a/src/features/lunch/react/index.ts
+++ b/src/features/lunch/react/index.ts
@@ -1,0 +1,1 @@
+export { useLunchMenuReactionAction } from './model/useLunchMenuReactionAction';

--- a/src/features/lunch/react/model/useLunchMenuReactionAction.ts
+++ b/src/features/lunch/react/model/useLunchMenuReactionAction.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { useState } from 'react';
+import { patchLunchMenuReaction, type LunchReactionType, type MainLunchMenu } from '@/entities/lunch-menu';
+import { getApiMessage } from '@/shared/lib/api/getApiMessage';
+import { cancelLunchMenuReaction, dislikeLunchMenu, likeLunchMenu } from '../api';
+
+interface UseLunchMenuReactionActionParams {
+  onRequireLogin: () => void;
+}
+
+export const useLunchMenuReactionAction = ({ onRequireLogin }: UseLunchMenuReactionActionParams) => {
+  const queryClient = useQueryClient();
+  const [reactionErrorMessage, setReactionErrorMessage] = useState('');
+  const reactionMutation = useMutation({
+    mutationFn: ({ menuId, nextReaction }: { menuId: number; nextReaction: LunchReactionType }) => {
+      if (nextReaction === 'LIKE') return likeLunchMenu(menuId);
+      if (nextReaction === 'DISLIKE') return dislikeLunchMenu(menuId);
+      return cancelLunchMenuReaction(menuId);
+    },
+  });
+
+  const applyReaction = async (menu: MainLunchMenu, reaction: 'LIKE' | 'DISLIKE') => {
+    setReactionErrorMessage('');
+    const nextReaction: LunchReactionType = menu.myReaction === reaction ? null : reaction;
+
+    try {
+      const result = await reactionMutation.mutateAsync({ menuId: menu.id, nextReaction });
+
+      patchLunchMenuReaction(queryClient, menu.id, {
+        myReaction: result.actionType,
+        likeCount: result.likeCount,
+        dislikeCount: result.dislikeCount,
+      });
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 401) {
+        setReactionErrorMessage('로그인 후 반응을 남길 수 있어요.');
+        onRequireLogin();
+        return;
+      }
+
+      setReactionErrorMessage(getApiMessage(error, '반응을 반영하지 못했어요.'));
+    }
+  };
+
+  return {
+    reactionErrorMessage,
+    setReactionErrorMessage,
+    handleLike: (menu: MainLunchMenu) => applyReaction(menu, 'LIKE'),
+    handleDislike: (menu: MainLunchMenu) => applyReaction(menu, 'DISLIKE'),
+    isReactionPending: reactionMutation.isPending,
+  };
+};

--- a/src/features/lunch/react/model/useLunchMenuReactionAction.ts
+++ b/src/features/lunch/react/model/useLunchMenuReactionAction.ts
@@ -1,7 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { useState } from 'react';
-import { patchLunchMenuReaction, type LunchReactionType, type MainLunchMenu } from '@/entities/lunch-menu';
+import {
+  lunchMenuQueryKeys,
+  patchLunchMenuReaction,
+  type LunchReactionType,
+  type MainLunchMenu,
+} from '@/entities/lunch-menu';
 import { getApiMessage } from '@/shared/lib/api/getApiMessage';
 import { cancelLunchMenuReaction, dislikeLunchMenu, likeLunchMenu } from '../api';
 
@@ -32,6 +37,8 @@ export const useLunchMenuReactionAction = ({ onRequireLogin }: UseLunchMenuReact
         likeCount: result.likeCount,
         dislikeCount: result.dislikeCount,
       });
+
+      await queryClient.invalidateQueries({ queryKey: lunchMenuQueryKeys.rankings('LIKE') });
     } catch (error) {
       if (isAxiosError(error) && error.response?.status === 401) {
         setReactionErrorMessage('로그인 후 반응을 남길 수 있어요.');

--- a/src/pages/main/ui/layout/main-tab-section/ui/MainTabSection.tsx
+++ b/src/pages/main/ui/layout/main-tab-section/ui/MainTabSection.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import type { PostSyncRequest } from '@/entities/post';
 import { myRoomQueryOptions, type RoomSyncRequest } from '@/entities/room';
 import { myUserQueryOptions } from '@/entities/user';
-import { lunchMenuListQueryOptions, lunchMenuQueryKeys, type MainLunchMenu } from '@/entities/lunch-menu';
+import { lunchMenuListQueryOptions, lunchMenuRankingsQueryOptions } from '@/entities/lunch-menu';
 import { authSessionSelectors, useAuthSessionStore } from '@/shared/lib/auth/session';
 import type { MainTab } from '../../main-tabs/model/types';
 import LunchSection from '@/widgets/lunch-section';
@@ -48,7 +48,6 @@ const MainTabSection = ({
   onRoomSyncHandled,
   onRequireLogin,
 }: MainTabSectionProps) => {
-  const queryClient = useQueryClient();
   const isRoomTab = activeTab === 'ROOM';
   const isPostTab = activeTab === 'POST';
   const myUserQuery = useQuery(myUserQueryOptions());
@@ -60,71 +59,23 @@ const MainTabSection = ({
   const lunchMenusQuery = useQuery(lunchMenuListQueryOptions());
   const lunchMenus = useMemo(() => lunchMenusQuery.data ?? [], [lunchMenusQuery.data]);
 
+  const lunchRankingsQuery = useQuery({
+    ...lunchMenuRankingsQueryOptions('LIKE'),
+    enabled: activeTab === 'RANKING',
+  });
   const rankings = useMemo<MainRankingItem[]>(
     () =>
-      [...lunchMenus]
-        .sort((a, b) => b.likeCount - a.likeCount)
-        .map((menu, index) => ({
-          id: menu.id,
-          rank: index + 1,
-          menuName: menu.menuName,
-          mealType: menu.mealType,
-          schoolInfo: menu.schoolInfo,
-          likeCount: menu.likeCount,
-          dislikeCount: menu.dislikeCount,
-        })),
-    [lunchMenus],
+      (lunchRankingsQuery.data ?? []).map((menu, index) => ({
+        id: menu.id,
+        rank: index + 1,
+        menuName: menu.menuName,
+        mealType: menu.mealType,
+        schoolInfo: menu.schoolInfo,
+        likeCount: menu.likeCount,
+        dislikeCount: menu.dislikeCount,
+      })),
+    [lunchRankingsQuery.data],
   );
-
-  const updateLunchMenusCache = (
-    updater: (menus: MainLunchMenu[]) => MainLunchMenu[],
-  ) => {
-    queryClient.setQueryData<MainLunchMenu[]>(lunchMenuQueryKeys.lists(), (currentMenus) =>
-      updater(currentMenus ?? []),
-    );
-  };
-
-  const handleLike = (menuId: number) => {
-    updateLunchMenusCache((currentMenus) =>
-      currentMenus.map((menu) => {
-        if (menu.id !== menuId) {
-          return menu;
-        }
-
-        const nextLikedByMe = !menu.likedByMe;
-        const removeDislike = Boolean(menu.dislikedByMe && nextLikedByMe);
-
-        return {
-          ...menu,
-          likedByMe: nextLikedByMe,
-          dislikedByMe: removeDislike ? false : menu.dislikedByMe,
-          likeCount: Math.max(0, menu.likeCount + (nextLikedByMe ? 1 : -1)),
-          dislikeCount: Math.max(0, menu.dislikeCount - (removeDislike ? 1 : 0)),
-        };
-      }),
-    );
-  };
-
-  const handleDislike = (menuId: number) => {
-    updateLunchMenusCache((currentMenus) =>
-      currentMenus.map((menu) => {
-        if (menu.id !== menuId) {
-          return menu;
-        }
-
-        const nextDislikedByMe = !menu.dislikedByMe;
-        const removeLike = Boolean(menu.likedByMe && nextDislikedByMe);
-
-        return {
-          ...menu,
-          dislikedByMe: nextDislikedByMe,
-          likedByMe: removeLike ? false : menu.likedByMe,
-          dislikeCount: Math.max(0, menu.dislikeCount + (nextDislikedByMe ? 1 : -1)),
-          likeCount: Math.max(0, menu.likeCount - (removeLike ? 1 : 0)),
-        };
-      }),
-    );
-  };
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -164,12 +115,7 @@ const MainTabSection = ({
         />
       ) : null}
       {activeTab === 'LUNCH' ? (
-        <LunchSection
-          lunchMenus={lunchMenus}
-          isAdmin={isAdmin}
-          onLike={handleLike}
-          onDislike={handleDislike}
-        />
+        <LunchSection lunchMenus={lunchMenus} isAdmin={isAdmin} onRequireLogin={onRequireLogin} />
       ) : null}
       {activeTab === 'RANKING' ? <RankingSection rankings={rankings} /> : null}
       {activeTab === 'POST' ? (

--- a/src/widgets/lunch-section/model/useLunchSelection.ts
+++ b/src/widgets/lunch-section/model/useLunchSelection.ts
@@ -6,10 +6,7 @@ interface UseLunchSelectionParams {
 }
 
 export const useLunchSelection = ({ lunchMenus }: UseLunchSelectionParams) => {
-  const initialSelectedLunchMenuId = lunchMenus[0]?.id ?? null;
-  const [selectedLunchMenuId, setSelectedLunchMenuId] = useState<number | null>(
-    initialSelectedLunchMenuId,
-  );
+  const [selectedLunchMenuId, setSelectedLunchMenuId] = useState<number | null>(null);
   const selectedLunchMenu = useMemo(
     () => lunchMenus.find((lunchMenu) => lunchMenu.id === selectedLunchMenuId) ?? null,
     [lunchMenus, selectedLunchMenuId],

--- a/src/widgets/lunch-section/ui/LunchMenuCard.tsx
+++ b/src/widgets/lunch-section/ui/LunchMenuCard.tsx
@@ -74,23 +74,25 @@ const LunchMenuCard = ({
       <div className="rounded-2xl bg-emerald-50 px-4 py-3 text-right">
         <div className="text-xs font-semibold text-emerald-600">한 끼 정보</div>
         <div className="mt-2 text-lg font-bold text-slate-900">
-          {KRW_NUMBER_FORMAT.format(menu.price)}원
+          {menu.price !== null ? `${KRW_NUMBER_FORMAT.format(menu.price)}원` : '가격 미정'}
         </div>
         <div className="mt-1 inline-flex items-center gap-1 text-sm text-slate-500">
           <Flame className="h-4 w-4 text-orange-400" />
-          {menu.calorie}kcal
+          {menu.calorie !== null ? `${menu.calorie}kcal` : '칼로리 미정'}
         </div>
       </div>
     </div>
 
     <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
       <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-2 text-slate-700">
-        <ThumbsUp className={`h-4 w-4 ${menu.likedByMe ? 'text-indigo-700' : 'text-indigo-500'}`} />
+        <ThumbsUp
+          className={`h-4 w-4 ${menu.myReaction === 'LIKE' ? 'text-indigo-700' : 'text-indigo-500'}`}
+        />
         좋아요 {menu.likeCount}
       </div>
       <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-2 text-slate-700">
         <ThumbsDown
-          className={`h-4 w-4 ${menu.dislikedByMe ? 'text-rose-700' : 'text-rose-500'}`}
+          className={`h-4 w-4 ${menu.myReaction === 'DISLIKE' ? 'text-rose-700' : 'text-rose-500'}`}
         />
         싫어요 {menu.dislikeCount}
       </div>

--- a/src/widgets/lunch-section/ui/LunchMenuDetail.tsx
+++ b/src/widgets/lunch-section/ui/LunchMenuDetail.tsx
@@ -7,28 +7,24 @@ interface LunchMenuDetailProps {
   menu: MainLunchMenu;
   onLike: (menuId: number) => void;
   onDislike: (menuId: number) => void;
+  isReactionPending?: boolean;
 }
 
-const LunchMenuDetail = ({ menu, onLike, onDislike }: LunchMenuDetailProps) => (
-  <article className="rounded-[32px] border border-emerald-100 bg-white p-6 shadow-[0_16px_40px_rgba(15,23,42,0.06)] md:p-7">
+const LunchMenuDetail = ({ menu, onLike, onDislike, isReactionPending }: LunchMenuDetailProps) => (
+  <div className="mt-6">
     <div className="flex flex-wrap items-start justify-between gap-4">
-      <div>
-        <div className="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-600">
-          {menu.schoolInfo} · {lunchMealTypeLabelMap[menu.mealType]}
-        </div>
-        <h3 className="mt-4 text-[26px] font-bold tracking-[-0.03em] text-slate-900">
-          {menu.menuName}
-        </h3>
+      <div className="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-600">
+        {menu.schoolInfo} · {lunchMealTypeLabelMap[menu.mealType]}
       </div>
 
       <div className="rounded-[24px] bg-emerald-50 px-5 py-4">
         <div className="text-xs font-semibold text-emerald-600">메뉴 정보</div>
         <div className="mt-2 text-xl font-bold text-slate-900">
-          {KRW_NUMBER_FORMAT.format(menu.price)}원
+          {menu.price !== null ? `${KRW_NUMBER_FORMAT.format(menu.price)}원` : '가격 미정'}
         </div>
         <div className="mt-2 flex items-center gap-1 text-sm text-slate-500">
           <Flame className="h-4 w-4 text-orange-400" />
-          {menu.calorie}kcal
+          {menu.calorie !== null ? `${menu.calorie}kcal` : '칼로리 미정'}
         </div>
       </div>
     </div>
@@ -53,8 +49,11 @@ const LunchMenuDetail = ({ menu, onLike, onDislike }: LunchMenuDetailProps) => (
       <button
         type="button"
         onClick={() => onLike(menu.id)}
-        className={`inline-flex items-center gap-2 rounded-2xl px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(99,102,241,0.22)] transition ${
-          menu.likedByMe ? 'bg-indigo-700 hover:bg-indigo-800' : 'bg-indigo-500 hover:bg-indigo-600'
+        disabled={isReactionPending}
+        className={`inline-flex items-center gap-2 rounded-2xl px-4 py-3 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(99,102,241,0.22)] transition disabled:cursor-not-allowed disabled:opacity-60 ${
+          menu.myReaction === 'LIKE'
+            ? 'bg-indigo-700 hover:bg-indigo-800'
+            : 'bg-indigo-500 hover:bg-indigo-600'
         }`}
       >
         <ThumbsUp className="h-4 w-4" />
@@ -63,8 +62,9 @@ const LunchMenuDetail = ({ menu, onLike, onDislike }: LunchMenuDetailProps) => (
       <button
         type="button"
         onClick={() => onDislike(menu.id)}
-        className={`inline-flex items-center gap-2 rounded-2xl px-4 py-3 text-sm font-semibold transition ${
-          menu.dislikedByMe
+        disabled={isReactionPending}
+        className={`inline-flex items-center gap-2 rounded-2xl px-4 py-3 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 ${
+          menu.myReaction === 'DISLIKE'
             ? 'bg-rose-600 text-white hover:bg-rose-700'
             : 'bg-rose-100 text-rose-700 hover:bg-rose-200'
         }`}
@@ -73,7 +73,7 @@ const LunchMenuDetail = ({ menu, onLike, onDislike }: LunchMenuDetailProps) => (
         싫어요 {menu.dislikeCount}
       </button>
     </div>
-  </article>
+  </div>
 );
 
 export default LunchMenuDetail;

--- a/src/widgets/lunch-section/ui/LunchSection.tsx
+++ b/src/widgets/lunch-section/ui/LunchSection.tsx
@@ -3,6 +3,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import LunchMenuEditorModal, { type LunchMenuEditorFormValues } from '@/features/lunch/editor';
 import DeleteLunchMenuConfirmModal, { useDeleteLunchMenuAction } from '@/features/lunch/delete';
+import { useLunchMenuReactionAction } from '@/features/lunch/react';
+import AppDialog from '@/shared/ui/modal/AppDialog';
 import { useLunchSelection } from '../model/useLunchSelection';
 import type { MainLunchMenu } from '../model/types';
 import LunchMenuCard from './LunchMenuCard';
@@ -11,20 +13,19 @@ import LunchMenuDetail from './LunchMenuDetail';
 interface LunchSectionProps {
   lunchMenus: MainLunchMenu[];
   isAdmin: boolean;
-  onLike: (menuId: number) => void;
-  onDislike: (menuId: number) => void;
+  onRequireLogin: () => void;
 }
 
 const toEditorFormValues = (menu: MainLunchMenu): LunchMenuEditorFormValues => ({
   mealType: menu.mealType,
   menuName: menu.menuName,
-  price: menu.price,
-  calorie: menu.calorie,
+  price: menu.price ?? 0,
+  calorie: menu.calorie ?? 0,
   schoolInfo: menu.schoolInfo,
   componentsText: menu.components.join(', '),
 });
 
-const LunchSection = ({ lunchMenus, isAdmin, onLike, onDislike }: LunchSectionProps) => {
+const LunchSection = ({ lunchMenus, isAdmin, onRequireLogin }: LunchSectionProps) => {
   const queryClient = useQueryClient();
   const { selectedLunchMenuId, setSelectedLunchMenuId, selectedLunchMenu } = useLunchSelection({
     lunchMenus,
@@ -41,6 +42,8 @@ const LunchSection = ({ lunchMenus, isAdmin, onLike, onDislike }: LunchSectionPr
     setSelectedLunchMenuId,
     closeDeleteConfirm: () => setDeleteTarget(null),
   });
+
+  const reactionAction = useLunchMenuReactionAction({ onRequireLogin });
 
   return (
     <section className="space-y-4 md:space-y-5">
@@ -74,9 +77,27 @@ const LunchSection = ({ lunchMenus, isAdmin, onLike, onDislike }: LunchSectionPr
         />
       ))}
 
-      {selectedLunchMenu ? (
-        <LunchMenuDetail menu={selectedLunchMenu} onLike={onLike} onDislike={onDislike} />
-      ) : null}
+      <AppDialog
+        isOpen={selectedLunchMenu !== null}
+        onClose={() => setSelectedLunchMenuId(null)}
+        title={selectedLunchMenu?.menuName ?? '학식 메뉴 상세'}
+      >
+        {selectedLunchMenu ? (
+          <>
+            <LunchMenuDetail
+              menu={selectedLunchMenu}
+              onLike={() => void reactionAction.handleLike(selectedLunchMenu)}
+              onDislike={() => void reactionAction.handleDislike(selectedLunchMenu)}
+              isReactionPending={reactionAction.isReactionPending}
+            />
+            {reactionAction.reactionErrorMessage ? (
+              <p className="mt-4 rounded-[20px] border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-600">
+                {reactionAction.reactionErrorMessage}
+              </p>
+            ) : null}
+          </>
+        ) : null}
+      </AppDialog>
 
       <LunchMenuEditorModal
         isOpen={isEditorOpen}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 학식 메뉴 관련 기능을 실제 백엔드 API와 연동

## ✨ 변경 사항 (Changes)

- 잘못된 API 경로 수정: `lunch-menus` → `meal-menus` (목록/생성/수정/삭제 전부)
- 좋아요/싫어요 실제 API 연동 (`POST /like`, `/dislike`, `DELETE /reaction`로 완전한 토글 UX 구현)
- 랭킹 전용 API(`GET /meal-menus/rankings`) 연동, 클라이언트 임시 정렬 로직 제거
- 학식 상세를 인라인 표시에서 모달로 전환

## 📸 스크린샷 (Screenshots)

- 스크린샷 첨부

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 참고 사항 기재

## 🧐 이슈 (Related Issues)

- Closes #175 
