### PR TITLE
feat: (#178) 댓글 API 연동

### DIFF
--- a/src/entities/comment/api/commentList.ts
+++ b/src/entities/comment/api/commentList.ts
@@ -7,8 +7,8 @@ export async function getComments(
 ): Promise<GetCommentsResponse> {
   const response = await client.get<GetCommentsResponse>(`/api/v1/posts/${postId}/comments`, {
     params: {
-      page: params.page,
-      size: params.size,
+      cursor: params.cursor,
+      limit: params.limit,
     },
   });
 

--- a/src/entities/comment/api/commentListQueries.ts
+++ b/src/entities/comment/api/commentListQueries.ts
@@ -1,13 +1,22 @@
-import { queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions } from '@tanstack/react-query';
 import type { GetCommentsParams } from '../model/types';
 import { getComments } from './commentList';
 import { commentQueryKeys } from './commentQueryKeys';
 
-export const postCommentsQueryOptions = (
+export const commentInfiniteListQueryOptions = (
   postId: number,
   params: GetCommentsParams = {},
+  limit = 10,
 ) =>
-  queryOptions({
-    queryKey: commentQueryKeys.list(postId, params),
-    queryFn: () => getComments(postId, params),
+  infiniteQueryOptions({
+    queryKey: commentQueryKeys.infiniteList(postId, { ...params, limit }),
+    initialPageParam: undefined as number | undefined,
+    queryFn: ({ pageParam }) =>
+      getComments(postId, {
+        ...params,
+        cursor: pageParam,
+        limit,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
   });

--- a/src/entities/comment/api/commentQueryKeys.ts
+++ b/src/entities/comment/api/commentQueryKeys.ts
@@ -1,6 +1,9 @@
+import type { GetCommentsParams } from '../model/types';
+
 export const commentQueryKeys = {
   all: () => ['comments'] as const,
   lists: () => [...commentQueryKeys.all(), 'list'] as const,
-  list: (postId: number, params: { page?: number; size?: number } = {}) =>
-    [...commentQueryKeys.lists(), postId, params] as const,
+  list: (postId: number) => [...commentQueryKeys.lists(), postId] as const,
+  infiniteList: (postId: number, params: GetCommentsParams = {}) =>
+    [...commentQueryKeys.list(postId), 'infinite', params] as const,
 };

--- a/src/entities/comment/index.ts
+++ b/src/entities/comment/index.ts
@@ -1,7 +1,7 @@
 export type {
+  CommentAuthor,
   CommentListItemResponse,
-  CommentListPaginationResponse,
-  CommentListUserResponse,
+  CommentDetailResponse,
   GetCommentsParams,
   GetCommentsResponse,
   CreateCommentRequest,
@@ -11,9 +11,9 @@ export type {
   UpdateCommentResponse,
 } from './model/types';
 export { getComments } from './api/commentList';
-export { postCommentsQueryOptions } from './api/commentListQueries';
+export { commentInfiniteListQueryOptions } from './api/commentListQueries';
 export { commentQueryKeys } from './api/commentQueryKeys';
 export type { MainPostComment } from './model/mainComment';
 export { invalidateCommentCaches, invalidateCommentList } from './model/commentCache';
-export { COMMENTS_LIST_DEFAULT_PAGE, COMMENTS_LIST_DEFAULT_SIZE } from './model/constants';
 export { toMainPostComment } from './model/commentMappers';
+export { default as CommentAuthorAvatar } from './ui/CommentAuthorAvatar';

--- a/src/entities/comment/model/commentMappers.ts
+++ b/src/entities/comment/model/commentMappers.ts
@@ -1,27 +1,14 @@
-import type { CommentListItemResponse } from './types';
+import type { CommentDetailResponse } from './types';
 import type { MainPostComment } from './mainComment';
 
-export const toMainPostComment = (
-  comment: CommentListItemResponse,
-  postId: number,
-  currentUserId: number | null,
-): MainPostComment => ({
+export const toMainPostComment = (comment: CommentDetailResponse, postId: number): MainPostComment => ({
   id: comment.id,
-  postId: comment.postId ?? postId,
-  author:
-    comment.author?.trim() ||
-    comment.authorNickname?.trim() ||
-    comment.userNickname?.trim() ||
-    comment.nickname?.trim() ||
-    comment.user?.nickname?.trim() ||
-    '익명 사용자',
+  postId,
+  authorNickname: comment.user?.nickname ?? '익명',
+  authorProfileImageUrl: comment.user?.profileImageUrl ?? null,
   content: comment.content,
-  likedCount: comment.likeCount ?? 0,
-  liked: comment.liked ?? false,
+  likeCount: comment.likeCount,
+  liked: comment.liked,
   createdAt: comment.createdAt,
-  isMine:
-    typeof comment.isMine === 'boolean'
-      ? comment.isMine
-      : currentUserId !== null &&
-        (comment.userId === currentUserId || comment.authorId === currentUserId),
+  isMine: comment.isMine,
 });

--- a/src/entities/comment/model/constants.ts
+++ b/src/entities/comment/model/constants.ts
@@ -1,2 +1,0 @@
-export const COMMENTS_LIST_DEFAULT_PAGE = 1;
-export const COMMENTS_LIST_DEFAULT_SIZE = 10;

--- a/src/entities/comment/model/mainComment.ts
+++ b/src/entities/comment/model/mainComment.ts
@@ -1,9 +1,10 @@
 export interface MainPostComment {
   id: number;
   postId: number;
-  author: string;
+  authorNickname: string;
+  authorProfileImageUrl: string | null;
   content: string;
-  likedCount: number;
+  likeCount: number;
   liked: boolean;
   createdAt: string;
   isMine: boolean;

--- a/src/entities/comment/model/types.ts
+++ b/src/entities/comment/model/types.ts
@@ -1,61 +1,44 @@
-export interface GetCommentsParams {
-  page?: number;
-  size?: number;
+export interface CommentAuthor {
+  id: number;
+  nickname: string;
+  profileImageUrl: string | null;
 }
 
-export interface CommentListUserResponse {
-  id?: number;
-  nickname?: string;
-  name?: string;
+export interface GetCommentsParams {
+  cursor?: number;
+  limit?: number;
 }
 
 export interface CommentListItemResponse {
   id: number;
-  postId?: number | null;
-  userId?: number | null;
-  authorId?: number | null;
   content: string;
-  likeCount?: number | null;
-  liked?: boolean | null;
   createdAt: string;
-  author?: string | null;
-  authorNickname?: string | null;
-  userNickname?: string | null;
-  nickname?: string | null;
-  isMine?: boolean | null;
-  user?: CommentListUserResponse | null;
+  likeCount: number;
+  user: CommentAuthor | null;
+  liked: boolean;
+  isMine: boolean;
 }
 
-export interface CommentListPaginationResponse {
-  page?: number;
-  size?: number;
-  totalCount?: number;
-  totalPages?: number;
-  hasNext?: boolean;
-}
+export type CommentDetailResponse = CommentListItemResponse;
 
 export interface GetCommentsResponse {
   items: CommentListItemResponse[];
-  pagination?: CommentListPaginationResponse;
+  nextCursor: number | null;
+  hasNext: boolean;
 }
 
 export interface CreateCommentRequest {
   content: string;
+  isAnonymous: boolean;
 }
 
-export interface CreateCommentResponse extends CommentListItemResponse {
-  postId: number;
-}
+export type UpdateCommentRequest = Partial<CreateCommentRequest>;
 
-export interface UpdateCommentRequest {
-  content: string;
-}
-
-export interface UpdateCommentResponse extends CommentListItemResponse {
-  postId: number;
-}
+export type CreateCommentResponse = CommentDetailResponse;
+export type UpdateCommentResponse = CommentDetailResponse;
 
 export interface LikeCommentResponse {
+  commentId: number;
   liked: boolean;
   likeCount: number;
 }

--- a/src/entities/comment/ui/CommentAuthorAvatar.tsx
+++ b/src/entities/comment/ui/CommentAuthorAvatar.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+interface CommentAuthorAvatarProps {
+  nickname: string;
+  profileImageUrl: string | null;
+  size?: 'sm' | 'md';
+}
+
+const sizeClassMap = {
+  sm: 'h-6 w-6 text-[10px]',
+  md: 'h-9 w-9 text-xs',
+};
+
+const CommentAuthorAvatar = ({
+  nickname,
+  profileImageUrl,
+  size = 'sm',
+}: CommentAuthorAvatarProps) => {
+  const [imageError, setImageError] = useState(false);
+  const displayNickname = nickname.trim() || '익명';
+  const showImage = Boolean(profileImageUrl) && !imageError;
+  const initial = displayNickname.charAt(0).toUpperCase();
+
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-slate-200 font-semibold text-slate-600 ${sizeClassMap[size]}`}
+    >
+      {showImage ? (
+        <img
+          src={profileImageUrl ?? undefined}
+          alt={`${displayNickname} 프로필`}
+          className="h-full w-full object-cover"
+          onError={() => setImageError(true)}
+        />
+      ) : (
+        initial
+      )}
+    </span>
+  );
+};
+
+export default CommentAuthorAvatar;

--- a/src/features/comment/create/model/useCreateCommentAction.ts
+++ b/src/features/comment/create/model/useCreateCommentAction.ts
@@ -17,11 +17,19 @@ export const useCreateCommentAction = ({
   invalidateCommentCaches,
 }: UseCreateCommentActionParams) => {
   const [commentInputValue, setCommentInputValue] = useState('');
+  const [isCommentAnonymous, setIsCommentAnonymous] = useState(false);
   const [commentActionMessage, setCommentActionMessage] = useState('');
   const [commentActionTone, setCommentActionTone] = useState<'success' | 'error'>('success');
   const createCommentMutation = useMutation({
-    mutationFn: ({ postId, content }: { postId: number; content: string }) =>
-      createComment(postId, { content }),
+    mutationFn: ({
+      postId,
+      content,
+      isAnonymous,
+    }: {
+      postId: number;
+      content: string;
+      isAnonymous: boolean;
+    }) => createComment(postId, { content, isAnonymous }),
   });
 
   const handleCommentSubmit = async () => {
@@ -41,8 +49,13 @@ export const useCreateCommentAction = ({
     }
 
     try {
-      await createCommentMutation.mutateAsync({ postId: selectedPostId, content: trimmedContent });
+      await createCommentMutation.mutateAsync({
+        postId: selectedPostId,
+        content: trimmedContent,
+        isAnonymous: isCommentAnonymous,
+      });
       setCommentInputValue('');
+      setIsCommentAnonymous(false);
       setCommentActionMessage('댓글을 등록했어요.');
       setCommentActionTone('success');
       await invalidateCommentCaches(selectedPostId);
@@ -60,12 +73,15 @@ export const useCreateCommentAction = ({
   return {
     commentInputValue,
     setCommentInputValue,
+    isCommentAnonymous,
+    setIsCommentAnonymous,
     handleCommentSubmit,
     isCommentSubmitPending: createCommentMutation.isPending,
     commentActionMessage,
     commentActionTone,
     resetCommentComposerState: () => {
       setCommentInputValue('');
+      setIsCommentAnonymous(false);
       setCommentActionMessage('');
       setCommentActionTone('success');
     },

--- a/src/features/comment/react/api.ts
+++ b/src/features/comment/react/api.ts
@@ -8,3 +8,14 @@ export async function likeComment(postId: number, commentId: number): Promise<Li
 
   return response.data;
 }
+
+export async function unlikeComment(
+  postId: number,
+  commentId: number,
+): Promise<LikeCommentResponse> {
+  const response = await client.delete<LikeCommentResponse>(
+    `/api/v1/posts/${postId}/comments/${commentId}/like`,
+  );
+
+  return response.data;
+}

--- a/src/features/comment/react/index.ts
+++ b/src/features/comment/react/index.ts
@@ -1,2 +1,2 @@
-export { likeComment } from './api';
+export { likeComment, unlikeComment } from './api';
 export { useCommentReactionAction } from './model/useCommentReactionAction';

--- a/src/features/comment/react/model/useCommentReactionAction.ts
+++ b/src/features/comment/react/model/useCommentReactionAction.ts
@@ -3,7 +3,7 @@ import { isAxiosError } from 'axios';
 import { isAuthenticated } from '@/shared/lib/auth/session';
 import { getApiMessage } from '@/shared/lib/api/getApiMessage';
 import type { MainPostComment } from '@/entities/comment';
-import { likeComment } from '../api';
+import { likeComment, unlikeComment } from '../api';
 import { useCommentReactionState } from './useCommentReactionState';
 
 interface UseCommentReactionActionParams {
@@ -17,8 +17,10 @@ export const useCommentReactionAction = ({
 }: UseCommentReactionActionParams) => {
   const reactionState = useCommentReactionState();
   const likeCommentMutation = useMutation({
-    mutationFn: ({ postId, commentId }: { postId: number; commentId: number }) =>
-      likeComment(postId, commentId),
+    mutationFn: (comment: MainPostComment) =>
+      comment.liked
+        ? unlikeComment(comment.postId, comment.id)
+        : likeComment(comment.postId, comment.id),
   });
 
   const handleCommentReaction = async (comment: MainPostComment) => {
@@ -31,7 +33,7 @@ export const useCommentReactionAction = ({
 
     try {
       reactionState.setLikingCommentId(comment.id);
-      await likeCommentMutation.mutateAsync({ postId: comment.postId, commentId: comment.id });
+      await likeCommentMutation.mutateAsync(comment);
       await invalidateCommentCaches(comment.postId);
     } catch (error) {
       reactionState.setCommentLikeTone('error');

--- a/src/widgets/post-section/comment/model/types.ts
+++ b/src/widgets/post-section/comment/model/types.ts
@@ -33,6 +33,8 @@ export interface CommentItemActions {
 export interface CommentComposerState {
   inputValue: string;
   changeInputValue: (value: string) => void;
+  isAnonymous: boolean;
+  changeIsAnonymous: (value: boolean) => void;
   submit: () => Promise<void>;
   isPending: boolean;
   message: string;
@@ -71,6 +73,9 @@ export interface PostCommentSectionState {
   composer: CommentComposerState;
   editor: CommentEditorState;
   reactions: CommentReactionState;
+  loadMoreRef: React.RefObject<HTMLDivElement | null>;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
 }
 
 export interface PostCommentSectionControllerState {

--- a/src/widgets/post-section/comment/model/useCommentThreadController.ts
+++ b/src/widgets/post-section/comment/model/useCommentThreadController.ts
@@ -43,6 +43,8 @@ export const useCommentThreadController = ({
   const composer: CommentComposerState = {
     inputValue: composerAction.commentInputValue,
     changeInputValue: composerAction.setCommentInputValue,
+    isAnonymous: composerAction.isCommentAnonymous,
+    changeIsAnonymous: composerAction.setIsCommentAnonymous,
     submit: composerAction.handleCommentSubmit,
     isPending: composerAction.isCommentSubmitPending,
     message: composerAction.commentActionMessage,

--- a/src/widgets/post-section/comment/ui/CommentComposer.tsx
+++ b/src/widgets/post-section/comment/ui/CommentComposer.tsx
@@ -16,7 +16,16 @@ const CommentComposer = ({ composer }: CommentComposerProps) => (
         placeholder="댓글을 입력해주세요"
         className="w-full resize-none rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm outline-none transition focus:border-indigo-400 focus:ring-4 focus:ring-indigo-100"
       />
-      <div className="mt-3 flex justify-end">
+      <div className="mt-3 flex items-center justify-between">
+        <label className="flex items-center gap-2 text-sm text-slate-600">
+          <input
+            type="checkbox"
+            checked={composer.isAnonymous}
+            onChange={(event) => composer.changeIsAnonymous(event.target.checked)}
+            className="h-4 w-4 rounded border-slate-300 text-indigo-500 focus:ring-indigo-400"
+          />
+          익명으로 작성
+        </label>
         <button
           type="button"
           onClick={() => void composer.submit()}

--- a/src/widgets/post-section/comment/ui/CommentItemHeader.tsx
+++ b/src/widgets/post-section/comment/ui/CommentItemHeader.tsx
@@ -1,5 +1,5 @@
 import { PencilLine, Trash2 } from 'lucide-react';
-import type { MainPostComment } from '@/entities/comment';
+import { CommentAuthorAvatar, type MainPostComment } from '@/entities/comment';
 import { formatPostDetailDate } from '@/shared/lib/date/formatCreatedAt';
 
 interface CommentItemHeaderProps {
@@ -14,9 +14,15 @@ const CommentItemHeader = ({
   onDeleteStart,
 }: CommentItemHeaderProps) => (
   <div className="flex items-start justify-between gap-4">
-    <div>
-      <p className="font-semibold text-slate-800">{comment.author}</p>
-      <p className="mt-1 text-xs text-slate-400">{formatPostDetailDate(comment.createdAt)}</p>
+    <div className="flex items-center gap-2">
+      <CommentAuthorAvatar
+        nickname={comment.authorNickname}
+        profileImageUrl={comment.authorProfileImageUrl}
+      />
+      <div>
+        <p className="font-semibold text-slate-800">{comment.authorNickname}</p>
+        <p className="mt-1 text-xs text-slate-400">{formatPostDetailDate(comment.createdAt)}</p>
+      </div>
     </div>
     {comment.isMine ? (
       <div className="flex items-center gap-2">

--- a/src/widgets/post-section/comment/ui/CommentItemReactionBar.tsx
+++ b/src/widgets/post-section/comment/ui/CommentItemReactionBar.tsx
@@ -22,7 +22,7 @@ const CommentItemReactionBar = ({ comment, isLiking, onLike }: CommentItemReacti
       )}
     >
       <Heart className="h-4 w-4" />
-      {isLiking ? '반영 중...' : comment.likedCount}
+      {isLiking ? '반영 중...' : comment.likeCount}
     </button>
   </div>
 );

--- a/src/widgets/post-section/comment/ui/CommentList.tsx
+++ b/src/widgets/post-section/comment/ui/CommentList.tsx
@@ -11,6 +11,9 @@ interface CommentListProps {
   viewState: CommentListViewState;
   itemState: CommentItemState;
   itemActions: CommentItemActions;
+  loadMoreRef: React.RefObject<HTMLDivElement | null>;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
 }
 
 const CommentList = ({
@@ -18,6 +21,9 @@ const CommentList = ({
   viewState,
   itemState,
   itemActions,
+  loadMoreRef,
+  hasNextPage,
+  isFetchingNextPage,
 }: CommentListProps) => {
   if (viewState.isLoading) {
     return (
@@ -53,6 +59,12 @@ const CommentList = ({
           actions={itemActions}
         />
       ))}
+      {hasNextPage ? (
+        <div ref={loadMoreRef} className="h-1 w-full" aria-hidden="true" />
+      ) : null}
+      {isFetchingNextPage ? (
+        <p className="text-center text-xs text-slate-400">댓글을 더 불러오는 중...</p>
+      ) : null}
     </>
   );
 };

--- a/src/widgets/post-section/comment/ui/PostCommentSection.tsx
+++ b/src/widgets/post-section/comment/ui/PostCommentSection.tsx
@@ -62,6 +62,9 @@ const PostCommentSection = ({ comments }: PostCommentSectionProps) => {
         viewState={viewState}
         itemState={itemState}
         itemActions={itemActions}
+        loadMoreRef={comments.loadMoreRef}
+        hasNextPage={comments.hasNextPage}
+        isFetchingNextPage={comments.isFetchingNextPage}
       />
     </section>
   );

--- a/src/widgets/post-section/model/usePostCommentSectionState.ts
+++ b/src/widgets/post-section/model/usePostCommentSectionState.ts
@@ -34,6 +34,9 @@ export const usePostCommentSectionState = ({
       composer: commentThread.composer,
       editor: commentThread.editor,
       reactions: commentThread.reactions,
+      loadMoreRef: selectedPostCommentsQuery.loadMoreRef,
+      hasNextPage: selectedPostCommentsQuery.hasNextPage,
+      isFetchingNextPage: selectedPostCommentsQuery.isFetchingNextPage,
     },
     actions: {
       resetTransientState: commentThread.resetCommentTransientState,

--- a/src/widgets/post-section/model/usePostSectionData.ts
+++ b/src/widgets/post-section/model/usePostSectionData.ts
@@ -1,5 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
-import { myUserQueryOptions } from '@/entities/user';
 import type { PostSyncRequest } from '@/entities/post';
 import { useInfinitePosts } from './useInfinitePosts';
 import { useSelectedPostCommentsQuery } from './useSelectedPostCommentsQuery';
@@ -14,8 +12,6 @@ export const usePostSectionData = ({
   postSyncRequest,
   onPostSyncHandled,
 }: UsePostSectionDataParams) => {
-  const { data: myUserData } = useQuery(myUserQueryOptions());
-  const myUserId = myUserData?.id ?? null;
   const infinitePosts = useInfinitePosts();
   const postSelection = usePostSelection({
     postSyncRequest,
@@ -23,7 +19,6 @@ export const usePostSectionData = ({
   });
   const selectedPostCommentsQuery = useSelectedPostCommentsQuery({
     selectedPostId: postSelection.selectedPostId,
-    myUserId,
   });
 
   return {

--- a/src/widgets/post-section/model/useSelectedPostCommentsQuery.ts
+++ b/src/widgets/post-section/model/useSelectedPostCommentsQuery.ts
@@ -1,26 +1,20 @@
-import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import {
-  COMMENTS_LIST_DEFAULT_PAGE,
-  COMMENTS_LIST_DEFAULT_SIZE,
-  postCommentsQueryOptions,
-  toMainPostComment,
-} from '@/entities/comment';
+import { useEffect, useMemo, useRef } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { commentInfiniteListQueryOptions, toMainPostComment } from '@/entities/comment';
+
+const COMMENT_LIST_DEFAULT_LIMIT = 10;
 
 interface UsePostCommentsParams {
   selectedPostId: number | null;
-  myUserId: number | null;
 }
 
 export const useSelectedPostCommentsQuery = ({
   selectedPostId,
-  myUserId,
 }: UsePostCommentsParams) => {
-  const commentsQuery = useQuery({
-    ...postCommentsQueryOptions(selectedPostId ?? 0, {
-      page: COMMENTS_LIST_DEFAULT_PAGE,
-      size: COMMENTS_LIST_DEFAULT_SIZE,
-    }),
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  const commentsQuery = useInfiniteQuery({
+    ...commentInfiniteListQueryOptions(selectedPostId ?? 0, {}, COMMENT_LIST_DEFAULT_LIMIT),
     enabled: selectedPostId !== null,
   });
 
@@ -28,14 +22,33 @@ export const useSelectedPostCommentsQuery = ({
     () =>
       selectedPostId === null
         ? []
-        : (commentsQuery.data?.items ?? []).map((comment) =>
-            toMainPostComment(comment, selectedPostId, myUserId),
+        : (commentsQuery.data?.pages.flatMap((page) => page.items) ?? []).map((comment) =>
+            toMainPostComment(comment, selectedPostId),
           ),
-    [commentsQuery.data?.items, myUserId, selectedPostId],
+    [commentsQuery.data, selectedPostId],
   );
+
+  const { fetchNextPage, hasNextPage, isError, isFetchingNextPage, isLoading } = commentsQuery;
+
+  useEffect(() => {
+    const target = loadMoreRef.current;
+    if (!target || isLoading || isError || !hasNextPage) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries;
+      if (!entry?.isIntersecting || isFetchingNextPage || !hasNextPage) return;
+      void fetchNextPage();
+    });
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isError, isFetchingNextPage, isLoading]);
 
   return {
     commentsQuery,
     selectedPostComments,
+    loadMoreRef,
+    hasNextPage: hasNextPage ?? false,
+    isFetchingNextPage,
   };
 };

--- a/src/widgets/post-section/ui/PostDetailBody.tsx
+++ b/src/widgets/post-section/ui/PostDetailBody.tsx
@@ -1,21 +1,54 @@
+import { PencilLine, Trash2 } from 'lucide-react';
 import { PostAuthorAvatar, type MainPostDetail } from '@/entities/post';
 import { formatPostDetailDate } from '@/shared/lib/date/formatCreatedAt';
 
 interface PostDetailBodyProps {
   selectedPostDetail: MainPostDetail;
+  canEditSelectedPost: boolean;
+  onEditOpen: () => void;
+  onDeleteOpen: () => void;
 }
 
-const PostDetailBody = ({ selectedPostDetail }: PostDetailBodyProps) => (
+const PostDetailBody = ({
+  selectedPostDetail,
+  canEditSelectedPost,
+  onEditOpen,
+  onDeleteOpen,
+}: PostDetailBodyProps) => (
   <>
-    <div className="mt-3 flex items-center gap-2">
-      <PostAuthorAvatar
-        nickname={selectedPostDetail.authorNickname}
-        profileImageUrl={selectedPostDetail.authorProfileImageUrl}
-      />
-      <p className="text-sm font-medium text-slate-500">{selectedPostDetail.authorNickname}</p>
-      <span className="text-sm text-slate-400">
-        {formatPostDetailDate(selectedPostDetail.createdAt)}
-      </span>
+    <div className="mt-3 flex items-center justify-between gap-3">
+      <div className="flex items-center gap-2">
+        <PostAuthorAvatar
+          nickname={selectedPostDetail.authorNickname}
+          profileImageUrl={selectedPostDetail.authorProfileImageUrl}
+        />
+        <p className="text-sm font-medium text-slate-500">{selectedPostDetail.authorNickname}</p>
+        <span className="text-sm text-slate-400">
+          {formatPostDetailDate(selectedPostDetail.createdAt)}
+        </span>
+      </div>
+      {canEditSelectedPost ? (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onEditOpen}
+            aria-label="게시글 수정"
+            title="게시글 수정"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-slate-100 text-slate-500 transition hover:bg-slate-200"
+          >
+            <PencilLine className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onDeleteOpen}
+            aria-label="게시글 삭제"
+            title="게시글 삭제"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-rose-50 text-rose-500 transition hover:bg-rose-100"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      ) : null}
     </div>
     <p className="mt-6 whitespace-pre-wrap text-[15px] leading-7 text-slate-600">
       {selectedPostDetail.content}

--- a/src/widgets/post-section/ui/PostDetailHeader.tsx
+++ b/src/widgets/post-section/ui/PostDetailHeader.tsx
@@ -1,44 +1,11 @@
-import { PencilLine, Trash2 } from 'lucide-react';
 import { PostCategoryBadge, type MainPostDetail } from '@/entities/post';
 
 interface PostDetailHeaderProps {
   selectedPostDetail: MainPostDetail;
-  canEditSelectedPost: boolean;
-  onEditOpen: () => void;
-  onDeleteOpen: () => void;
 }
 
-const PostDetailHeader = ({
-  selectedPostDetail,
-  canEditSelectedPost,
-  onEditOpen,
-  onDeleteOpen,
-}: PostDetailHeaderProps) => (
-  <div className="flex flex-wrap items-center justify-between gap-3">
-    <div className="flex items-center gap-3">
-      <PostCategoryBadge category={selectedPostDetail.category} />
-    </div>
-    {canEditSelectedPost ? (
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onEditOpen}
-          className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
-        >
-          <PencilLine className="h-4 w-4" />
-          수정
-        </button>
-        <button
-          type="button"
-          onClick={onDeleteOpen}
-          className="inline-flex items-center gap-2 rounded-2xl bg-rose-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-rose-600"
-        >
-          <Trash2 className="h-4 w-4" />
-          삭제
-        </button>
-      </div>
-    ) : null}
-  </div>
+const PostDetailHeader = ({ selectedPostDetail }: PostDetailHeaderProps) => (
+  <PostCategoryBadge category={selectedPostDetail.category} />
 );
 
 export default PostDetailHeader;

--- a/src/widgets/post-section/ui/PostDetailPanel.tsx
+++ b/src/widgets/post-section/ui/PostDetailPanel.tsx
@@ -24,13 +24,13 @@ const PostDetailPanel = ({ detail, reactions, actions, comments }: PostDetailPan
 
           {!postDetailQuery.isLoading && !postDetailQuery.isError ? (
             <>
-              <PostDetailHeader
+              <PostDetailHeader selectedPostDetail={selectedPostDetail} />
+              <PostDetailBody
                 selectedPostDetail={selectedPostDetail}
                 canEditSelectedPost={canEditSelectedPost}
                 onEditOpen={actions.onEditOpen}
                 onDeleteOpen={actions.onDeleteOpen}
               />
-              <PostDetailBody selectedPostDetail={selectedPostDetail} />
               <PostReactionBar
                 selectedPostDetail={selectedPostDetail}
                 reactionErrorMessage={reactions.reactionErrorMessage}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 자유게시판 댓글 기능을 실제 백엔드 API에 맞춰 적용

## ✨ 변경 사항 (Changes)

- 댓글 목록 조회를 cursor 기반 페이지네이션(`cursor`/`limit`)으로 전환하고 무한 스크롤 적용
- 작성자 닉네임 추측 로직 제거, `user: {id, nickname, profileImageUrl} | null` 응답 그대로 사용
- 댓글 작성 시 `isAnonymous` 필드 추가 (익명 작성 체크박스 UI 추가)
- 댓글 좋아요 취소(unlike) 연동
- 댓글 작성자 프로필 이미지 표시 추가
- `isMine` 필드 연동으로 익명 댓글도 본인 여부 판별

## 📸 스크린샷 (Screenshots)

- 스크린샷 첨부

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 참고 사항 기재

## 🧐 이슈 (Related Issues)

- Closes #178 
